### PR TITLE
fix(session): persist remember-me policy and stabilize cookie/blocked…

### DIFF
--- a/server/fishtest/http/boundary.py
+++ b/server/fishtest/http/boundary.py
@@ -225,6 +225,10 @@ def remember(
     session_data = _resolve_session_data(request.session)
     if session_data is not None:
         session_data["user"] = username
+        if max_age is None:
+            session_data.pop("remember_max_age", None)
+        else:
+            session_data["remember_max_age"] = max_age
     request.remember = max_age is not None
     request.remember_max_age = max_age
     raw_request = _resolve_raw_request(request)

--- a/server/fishtest/http/session_middleware.py
+++ b/server/fishtest/http/session_middleware.py
@@ -89,13 +89,13 @@ class FishtestSessionMiddleware:
             if message.get("type") == "http.response.start":
                 session_data = scope.get("session") or {}
                 headers = MutableHeaders(scope=message)
-                max_age = _max_age_from_scope(scope, self.max_age)
                 secure = _secure_from_scope(scope, https_only=self.https_only)
                 force_clear = bool(scope.get("session_force_clear", False))
 
                 if session_data:
                     session_data = _enforce_size_limit(session_data, signer)
                     scope["session"] = session_data
+                    max_age = _max_age_from_scope(scope, self.max_age, session_data)
                     data = b64encode(json.dumps(session_data).encode("utf-8"))
                     signed = signer.sign(data)
                     headers.append(
@@ -136,7 +136,13 @@ class FishtestSessionMiddleware:
         return self._signer
 
 
-def _max_age_from_scope(scope: Scope, fallback: int | None) -> int | None:
+def _max_age_from_scope(
+    scope: Scope,
+    fallback: int | None,
+    session_data: object,
+) -> int | None:
+    if "session_max_age" not in scope:
+        return _max_age_from_session_data(session_data, fallback)
     value = scope.get("session_max_age", fallback)
     if value is None:
         return None
@@ -150,6 +156,19 @@ def _secure_from_scope(scope: Scope, *, https_only: bool) -> bool:
     if isinstance(override, bool):
         return override
     return https_only or _is_https_scope(scope)
+
+
+def _max_age_from_session_data(
+    session_data: object,
+    fallback: int | None,
+) -> int | None:
+    if not isinstance(session_data, dict):
+        return fallback
+    typed_session_data = cast("dict[str, object]", session_data)
+    value = typed_session_data.get("remember_max_age")
+    if isinstance(value, int) and value >= 0:
+        return value
+    return fallback
 
 
 def _is_https_scope(scope: Scope) -> bool:
@@ -265,7 +284,7 @@ def _enforce_size_limit(
         return candidate
 
     minimal: dict[str, object] = {}
-    for key in ("user", "csrf_token", "created_at", "updated_at"):
+    for key in ("user", "csrf_token", "created_at", "updated_at", "remember_max_age"):
         if key in candidate:
             minimal[key] = candidate[key]
     return minimal

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -252,7 +252,7 @@ class TestHttpApi(unittest.TestCase):
     def test_request_version_invalid_json_body(self):
         response = self.client.post(
             "/api/request_version",
-            data=b"{",
+            content=b"{",
             headers={"content-type": "application/json"},
         )
         self.assertEqual(response.status_code, 400)
@@ -346,7 +346,7 @@ class TestHttpApi(unittest.TestCase):
         for path in endpoints:
             response = self.client.post(
                 path,
-                data=b"{",
+                content=b"{",
                 headers={"content-type": "application/json"},
             )
             self.assertEqual(response.status_code, 400)

--- a/server/tests/test_http_boundary.py
+++ b/server/tests/test_http_boundary.py
@@ -76,11 +76,11 @@ class TestHttpBoundary(unittest.TestCase):
             }
 
         client = self.TestClient(app)
+        client.cookies.set("demo", "cookie")
         response = client.get(
             "/shim",
             params={"a": "1", "b": "2"},
             headers={"x-test-header": "hello"},
-            cookies={"demo": "cookie"},
         )
         self.assertEqual(response.status_code, 200)
         data = response.json()
@@ -111,7 +111,7 @@ class TestHttpBoundary(unittest.TestCase):
 
         response = client.post(
             "/json",
-            data=b"{",
+            content=b"{",
             headers={"content-type": "application/json"},
         )
         self.assertEqual(response.status_code, 200)
@@ -223,6 +223,222 @@ class TestHttpBoundary(unittest.TestCase):
         cookie_lower = cookie.lower()
         self.assertIn("max-age=0", cookie_lower)
         self.assertIn("expires=", cookie_lower)
+
+    def test_session_remember_max_age_persists_across_requests(self):
+        from fishtest.http.boundary import commit_session_response, remember
+        from fishtest.http.cookie_session import load_session
+
+        app = self._build_app()
+
+        @app.get("/remember-persist")
+        async def _remember_persist_probe(request: Request):
+            session = load_session(request)
+            shim = SimpleNamespace(session=session, _remember=False, _forget=False)
+            remember(shim, "Tester", max_age=60)
+            response = Response("ok")
+            commit_session_response(request, session, shim, response)
+            return response
+
+        @app.get("/touch")
+        async def _touch_probe(request: Request):
+            _ = load_session(request)
+            return Response("ok")
+
+        client = self.TestClient(app)
+        remember_response = client.get("/remember-persist")
+        self.assertEqual(remember_response.status_code, 200)
+        remember_cookie = remember_response.headers.get("set-cookie", "")
+        self.assertIn("fishtest_session=", remember_cookie)
+        self.assertIn("Max-Age=60", remember_cookie)
+
+        touch_response = client.get("/touch")
+        self.assertEqual(touch_response.status_code, 200)
+        touch_cookie = touch_response.headers.get("set-cookie", "")
+        self.assertIn("fishtest_session=", touch_cookie)
+        self.assertIn("Max-Age=60", touch_cookie)
+
+    def test_session_non_remember_cookie_stays_session_scoped(self):
+        from fishtest.http.boundary import commit_session_response, remember
+        from fishtest.http.cookie_session import load_session
+
+        app = self._build_app()
+
+        @app.get("/remember-session")
+        async def _remember_session_probe(request: Request):
+            session = load_session(request)
+            shim = SimpleNamespace(session=session, _remember=False, _forget=False)
+            remember(shim, "Tester")
+            response = Response("ok")
+            commit_session_response(request, session, shim, response)
+            return response
+
+        @app.get("/touch")
+        async def _touch_probe(request: Request):
+            _ = load_session(request)
+            return Response("ok")
+
+        client = self.TestClient(app)
+        remember_response = client.get("/remember-session")
+        self.assertEqual(remember_response.status_code, 200)
+        remember_cookie = remember_response.headers.get("set-cookie", "")
+        self.assertIn("fishtest_session=", remember_cookie)
+        self.assertNotIn("Max-Age=", remember_cookie)
+
+        touch_response = client.get("/touch")
+        self.assertEqual(touch_response.status_code, 200)
+        touch_cookie = touch_response.headers.get("set-cookie", "")
+        self.assertIn("fishtest_session=", touch_cookie)
+        self.assertNotIn("Max-Age=", touch_cookie)
+
+    def test_session_cookie_not_set_when_session_untouched(self):
+        app = self._build_app()
+
+        @app.get("/noop")
+        async def _noop_probe():
+            return Response("ok")
+
+        client = self.TestClient(app)
+        response = client.get("/noop")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.headers.get("set-cookie"))
+
+    def test_session_remember_then_non_remember_drops_max_age(self):
+        from fishtest.http.boundary import commit_session_response, remember
+        from fishtest.http.cookie_session import load_session
+
+        app = self._build_app()
+
+        @app.get("/login-remember")
+        async def _login_remember_probe(request: Request):
+            session = load_session(request)
+            shim = SimpleNamespace(session=session, _remember=False, _forget=False)
+            remember(shim, "Tester", max_age=60)
+            response = Response("ok")
+            commit_session_response(request, session, shim, response)
+            return response
+
+        @app.get("/login-session")
+        async def _login_session_probe(request: Request):
+            session = load_session(request)
+            shim = SimpleNamespace(session=session, _remember=False, _forget=False)
+            remember(shim, "Tester")
+            response = Response("ok")
+            commit_session_response(request, session, shim, response)
+            return response
+
+        client = self.TestClient(app)
+        remember_response = client.get("/login-remember")
+        self.assertEqual(remember_response.status_code, 200)
+        remember_cookie = remember_response.headers.get("set-cookie", "")
+        self.assertIn("Max-Age=60", remember_cookie)
+
+        session_response = client.get("/login-session")
+        self.assertEqual(session_response.status_code, 200)
+        session_cookie = session_response.headers.get("set-cookie", "")
+        self.assertIn("fishtest_session=", session_cookie)
+        self.assertNotIn("Max-Age=", session_cookie)
+
+    def test_session_remember_marks_secure_for_https(self):
+        from fishtest.http.boundary import commit_session_response, remember
+        from fishtest.http.cookie_session import load_session
+
+        app = self._build_app()
+
+        @app.get("/remember-https")
+        async def _remember_https_probe(request: Request):
+            session = load_session(request)
+            shim = SimpleNamespace(session=session, _remember=False, _forget=False)
+            remember(shim, "Tester", max_age=60)
+            response = Response("ok")
+            commit_session_response(request, session, shim, response)
+            return response
+
+        client = self.TestClient(app)
+        response = client.get("/remember-https", headers={"x-forwarded-proto": "https"})
+        self.assertEqual(response.status_code, 200)
+        cookie = response.headers.get("set-cookie", "").lower()
+        attrs = [part.strip() for part in cookie.split(";")[1:]]
+        self.assertIn("secure", attrs)
+
+    def test_session_remember_max_age_survives_size_limit_shrink(self):
+        from fishtest.http.boundary import commit_session_response, remember
+        from fishtest.http.cookie_session import load_session
+
+        app = self._build_app()
+
+        @app.get("/remember-large")
+        async def _remember_large_probe(request: Request):
+            session = load_session(request)
+            shim = SimpleNamespace(session=session, _remember=False, _forget=False)
+            remember(shim, "Tester", max_age=60)
+            session.data["blob"] = "x" * 20000
+            response = Response("ok")
+            commit_session_response(request, session, shim, response)
+            return response
+
+        @app.get("/inspect")
+        async def _inspect_probe(request: Request):
+            session = load_session(request)
+            data = session.data
+            return {
+                "has_blob": "blob" in data,
+                "remember_max_age": data.get("remember_max_age"),
+            }
+
+        client = self.TestClient(app)
+        remember_response = client.get("/remember-large")
+        self.assertEqual(remember_response.status_code, 200)
+        remember_cookie = remember_response.headers.get("set-cookie", "")
+        self.assertIn("Max-Age=60", remember_cookie)
+
+        inspect_response = client.get("/inspect")
+        self.assertEqual(inspect_response.status_code, 200)
+        inspect_cookie = inspect_response.headers.get("set-cookie", "")
+        self.assertIn("Max-Age=60", inspect_cookie)
+        inspect_body = inspect_response.json()
+        self.assertFalse(inspect_body["has_blob"])
+        self.assertEqual(inspect_body["remember_max_age"], 60)
+
+    def test_session_invalid_remember_marker_is_ignored(self):
+        from fishtest.http.cookie_session import load_session
+
+        app = self._build_app()
+
+        @app.get("/invalid-marker")
+        async def _invalid_marker_probe(request: Request):
+            session = load_session(request)
+            session.data["user"] = "Tester"
+            session.data["remember_max_age"] = "invalid"
+            return Response("ok")
+
+        client = self.TestClient(app)
+        response = client.get("/invalid-marker")
+        self.assertEqual(response.status_code, 200)
+        cookie = response.headers.get("set-cookie", "")
+        self.assertIn("fishtest_session=", cookie)
+        self.assertNotIn("Max-Age=", cookie)
+
+    def test_session_remember_zero_max_age_is_emitted(self):
+        from fishtest.http.boundary import commit_session_response, remember
+        from fishtest.http.cookie_session import load_session
+
+        app = self._build_app()
+
+        @app.get("/remember-zero")
+        async def _remember_zero_probe(request: Request):
+            session = load_session(request)
+            shim = SimpleNamespace(session=session, _remember=False, _forget=False)
+            remember(shim, "Tester", max_age=0)
+            response = Response("ok")
+            commit_session_response(request, session, shim, response)
+            return response
+
+        client = self.TestClient(app)
+        response = client.get("/remember-zero")
+        self.assertEqual(response.status_code, 200)
+        cookie = response.headers.get("set-cookie", "")
+        self.assertIn("Max-Age=0", cookie)
+        self.assertIn("Expires=", cookie)
 
     def test_session_forget_flags_force_cookie_clear(self):
         from fishtest.http.boundary import SessionCommitFlags, commit_session_flags

--- a/server/tests/test_http_helpers.py
+++ b/server/tests/test_http_helpers.py
@@ -229,7 +229,26 @@ class ErrorHandlerWorkerPathsTests(unittest.TestCase):
 
 
 class BlockedUserCacheTests(unittest.TestCase):
+    @staticmethod
+    def _restore_blocked_cache(cache_obj, timestamp, value):
+        cache_obj.timestamp = timestamp
+        cache_obj.value = value
+
     def test_blocked_cache_uses_ttl(self):
+        from fishtest.http.middleware import _blocked_cache
+
+        original_timestamp = _blocked_cache.timestamp
+        original_value = _blocked_cache.value
+        self.addCleanup(
+            self._restore_blocked_cache,
+            _blocked_cache,
+            original_timestamp,
+            original_value,
+        )
+
+        _blocked_cache.timestamp = None
+        _blocked_cache.value = None
+
         class FakeUserDb:
             def __init__(self):
                 self.calls = 0

--- a/server/tests/test_http_middleware.py
+++ b/server/tests/test_http_middleware.py
@@ -42,6 +42,21 @@ class TestHttpMiddleware(unittest.TestCase):
     def setUpClass(cls):
         cls.FastAPI, cls.TestClient = test_support.require_fastapi()
 
+    def setUp(self):
+        from fishtest.http.middleware import _blocked_cache
+
+        original_timestamp = _blocked_cache.timestamp
+        original_value = _blocked_cache.value
+
+        def _restore_cache_state():
+            _blocked_cache.timestamp = original_timestamp
+            _blocked_cache.value = original_value
+
+        self.addCleanup(_restore_cache_state)
+
+        _blocked_cache.timestamp = None
+        _blocked_cache.value = None
+
     def test_shutdown_guard_returns_503(self):
         rundb = _RunDbStub(shutdown=True)
         app = test_support.build_test_app(


### PR DESCRIPTION
…-cache tests

Persist remember-me policy in session data and reapply cookie Max-Age on subsequent responses when no per-request override is present.

Update remember() to store remember_max_age when max_age is provided, and clear that marker for non-remember logins.

Update session middleware to use stored remember_max_age as fallback when scope["session_max_age"] is not set, while preserving explicit request-level max-age precedence.

Stabilize blocked-user cache tests by resetting shared middleware cache state in affected test modules to remove inter-test coupling.

Expand cookie/session regression coverage for additional state and transition cases:
- untouched session does not emit session cookie
- remember -> non-remember transition drops Max-Age
- remember path marks cookie secure on HTTPS
- invalid remember marker is ignored
- remember max_age=0 is emitted

Add/extend regression tests for:
- remember login keeps Max-Age across consecutive requests
- non-remember login remains browser-session scoped
- blocked cache TTL test is deterministic
- middleware blocked-user redirect tests are isolated per test

Test-suite deprecation cleanup:
- replace deprecated raw-body upload style `data=b"..."` with `content=b"..."` in malformed-JSON request tests
- replace deprecated per-request TestClient `cookies={...}` usage with `client.cookies.set(...)`
- remove `httpx`/`starlette` deprecation warnings from touched tests