### PR TITLE
perf: reuse unfinished-run snapshots for batch polling

### DIFF
--- a/docs/4-ui-reference.md
+++ b/docs/4-ui-reference.md
@@ -56,7 +56,7 @@ registers it on the FastAPI router.
 | `/tests/tasks/{id}` | GET, POST | `tests_tasks` | `tasks_content_fragment.html.j2` | Fragment-only; updates the scrolling task table body and refreshes fixed controls/pagination OOB, with server-side sorting for every visible task column, one combined worker/info search filter, and 25-row pagination |
 | `/tests/machines` | GET, POST | `tests_machines` | `machines_fragment.html.j2` | Fragment-only, 10s cache |
 | `/tests/elo/{id}` | GET, POST | `tests_elo` | `elo_results_fragment.html.j2` | Fragment-only (OOB); standalone ELO/status/totals fragment |
-| `/tests/elo_batch` | GET, POST | `tests_elo_batch` | `elo_batch_fragment.html.j2` | Fragment-only (OOB batch) |
+| `/tests/elo_batch` | GET, POST | `tests_elo_batch` | `elo_batch_fragment.html.j2` | Fragment-only (OOB batch; unfinished panels use stripped run snapshots) |
 | `/tests/live_elo_update/{id}` | GET, POST | `live_elo_update` | `live_elo_fragment.html.j2` | Fragment-only (OOB) |
 | `/tests/finished` | GET, POST | `tests_finished` | `tests_finished.html.j2` | HX: `tests_finished_content_fragment` |
 | `/tests/user/{username}` | GET, POST | `tests_user` | `tests_user.html.j2` | HX: `tests_user_content_fragment` |
@@ -480,6 +480,14 @@ Behavior notes:
 - When workers filters are active and the Workers panel is collapsed, `/tests`
    and `/tests/elo_batch` recompute the filtered value from the current machine
    snapshot instead of reusing the last cookie-backed filtered count.
+- `/tests/elo_batch` rebuilds the unfinished panels from a stripped unfinished-
+   run snapshot that omits `tasks`, `bad_tasks`, and
+   `args.spsa.param_history`.
+- On the primary instance, that unfinished-run snapshot is copied from the
+   in-memory `unfinished_runs` set and run cache; on secondary instances it is
+   copied from a short-lived projected MongoDB snapshot.
+- The batch response still renders per request; the row fragment includes CSRF
+   form state, so the server does not share rendered batch HTML across users.
 - Machines sorting is fully server-authoritative; the old generic client-side
    header sorter has been retired.
 

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -847,10 +847,76 @@ class RunDb:
         )
         return unfinished_runs
 
+    def _snapshot_unfinished_run(self, run):
+        snapshot = {}
+        for key, value in run.items():
+            if key in ("tasks", "bad_tasks"):
+                continue
+            if key == "args":
+                snapshot[key] = {}
+                for arg_key, arg_value in value.items():
+                    if arg_key == "spsa":
+                        snapshot[key][arg_key] = {
+                            spsa_key: []
+                            if spsa_key == "param_history"
+                            else copy.deepcopy(spsa_value)
+                            for spsa_key, spsa_value in arg_value.items()
+                        }
+                        snapshot[key][arg_key].setdefault("param_history", [])
+                    else:
+                        snapshot[key][arg_key] = copy.deepcopy(arg_value)
+            else:
+                snapshot[key] = copy.deepcopy(value)
+        return snapshot
+
+    def _get_unfinished_runs_from_primary_cache(self):
+        with self.unfinished_runs_lock:
+            run_ids = list(self.unfinished_runs)
+
+        unfinished_runs = []
+        for run_id in run_ids:
+            run = self.get_run(run_id)
+            if run is None:
+                continue
+            with self.active_run_lock(run_id):
+                if run["finished"]:
+                    continue
+                snapshot = self._snapshot_unfinished_run(run)
+            results = snapshot.get("results")
+            if not isinstance(results, dict):
+                continue
+            if not {"wins", "losses", "draws"}.issubset(results):
+                continue
+            unfinished_runs.append(snapshot)
+
+        earliest_time = datetime.min.replace(tzinfo=UTC)
+        unfinished_runs.sort(
+            key=lambda run: run.get("last_updated") or earliest_time,
+            reverse=True,
+        )
+        return unfinished_runs
+
+    @lru_cache(maxsize=1, expiration=5, refresh=False)
+    def _get_unfinished_runs_from_db(self):
+        projection = {"tasks": 0, "bad_tasks": 0, "args.spsa.param_history": 0}
+        return list(
+            self.runs.find(
+                {"finished": False},
+                projection,
+                sort=[("last_updated", DESCENDING)],
+            )
+        )
+
     def get_unfinished_runs(self, username=None):
         # Note: the result can be only used once.
 
-        unfinished_runs = self.runs.find({"finished": False}, {"_id": 1, "tasks": 0})
+        if self.__is_primary_instance:
+            unfinished_runs = iter(self._get_unfinished_runs_from_primary_cache())
+        else:
+            unfinished_runs = (
+                self._snapshot_unfinished_run(run)
+                for run in self._get_unfinished_runs_from_db()
+            )
         if username:
             unfinished_runs = (
                 r for r in unfinished_runs if r["args"].get("username") == username

--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -11,6 +11,7 @@ from pymongo import DESCENDING
 
 from fishtest.api import WORKER_VERSION
 from fishtest.run_cache import Prio
+from fishtest.rundb import RunDb
 from fishtest.spsa_handler import _pack_flips, _unpack_flips
 
 
@@ -142,6 +143,59 @@ class CreateRunDBTest(unittest.TestCase):
         for run in self.rundb.get_unfinished_runs():
             if run["args"]["username"] == "travis":
                 print(run["args"])
+
+    def test_11_get_unfinished_runs_primary_returns_detached_snapshots(self):
+        run_id = self._create_test_run()
+        run = self.rundb.get_run(run_id)
+        run["results"]["wins"] = 11
+        run["results"]["losses"] = 7
+        run["args"]["spsa"] = {
+            "iter": 2,
+            "num_iter": 10,
+            "param_history": [{"theta": 1.0}],
+        }
+        run["bad_tasks"] = [{"task_id": 0}]
+        self.rundb.buffer(run, priority=Prio.SAVE_NOW)
+
+        snapshot = next(self.rundb.get_unfinished_runs())
+
+        self.assertNotIn("tasks", snapshot)
+        self.assertNotIn("bad_tasks", snapshot)
+        self.assertEqual(snapshot["args"]["spsa"]["param_history"], [])
+
+        snapshot["results"]["wins"] = 999
+        snapshot["args"]["info"] = "mutated"
+
+        live_run = self.rundb.get_run(run_id)
+        self.assertEqual(live_run["results"]["wins"], 11)
+        self.assertEqual(live_run["args"]["info"], "The ultimate patch")
+        self.assertEqual(
+            live_run["args"]["spsa"]["param_history"],
+            [{"theta": 1.0}],
+        )
+        self.assertIn("tasks", live_run)
+        self.assertIn("bad_tasks", live_run)
+
+    def test_12_get_unfinished_runs_secondary_omits_heavy_fields(self):
+        run_id = self._create_test_run()
+        run = self.rundb.get_run(run_id)
+        run["args"]["spsa"] = {
+            "iter": 3,
+            "num_iter": 12,
+            "param_history": [{"theta": 1.5}],
+        }
+        run["bad_tasks"] = [{"task_id": 1}]
+        self.rundb.buffer(run, priority=Prio.SAVE_NOW)
+
+        secondary = RunDb(db_name="fishtest_tests", is_primary_instance=False)
+        self.addCleanup(secondary.conn.close)
+
+        snapshot = next(secondary.get_unfinished_runs())
+
+        self.assertEqual(str(snapshot["_id"]), run_id)
+        self.assertNotIn("tasks", snapshot)
+        self.assertNotIn("bad_tasks", snapshot)
+        self.assertEqual(snapshot["args"]["spsa"]["param_history"], [])
 
     def test_20_update_task(self):
         run_id = self._create_test_run()


### PR DESCRIPTION
Reduce repeated homepage/user-page polling cost by sourcing unfinished-run snapshots from primary in-memory state and a short-lived secondary Mongo cache. Strip heavy task and SPSA history fields from the batch-facing snapshot while keeping rendered HTML request-specific.