### PR TITLE
perf: reuse stripped unfinished-run snapshots for live run tables

### DIFF
--- a/docs/5-templates.md
+++ b/docs/5-templates.md
@@ -922,6 +922,12 @@ submissions preserve the live table state.
 
 Behavior notes:
 
+- Unfinished panels are built from `aggregate_unfinished_runs()`, which reads
+   stripped unfinished-run snapshots. Primary instances derive those snapshots
+   from authoritative in-memory run state; secondaries reuse a projected 5s DB
+   snapshot. The stripped snapshot omits `tasks`, `bad_tasks`, and
+   `args.spsa.param_history` because this fragment only renders aggregate
+   run-table metadata.
 - When homepage workers filters are active, the fragment recomputes the
    `#workers-count` filtered value from the current machine snapshot instead of
    trusting the last cookie-backed filtered count.

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -847,10 +847,83 @@ class RunDb:
         )
         return unfinished_runs
 
+    def _snapshot_unfinished_run(self, run):
+        snapshot = {}
+        for key, value in run.items():
+            if key in ("tasks", "bad_tasks"):
+                continue
+            if key == "args":
+                snapshot[key] = {}
+                for arg_key, arg_value in value.items():
+                    if arg_key == "spsa":
+                        snapshot[key][arg_key] = {
+                            spsa_key: []
+                            if spsa_key == "param_history"
+                            else copy.deepcopy(spsa_value)
+                            for spsa_key, spsa_value in arg_value.items()
+                        }
+                        # Ensure param_history exists even if the source
+                        # SPSA dict lacks the optional key.
+                        snapshot[key][arg_key].setdefault("param_history", [])
+                    else:
+                        snapshot[key][arg_key] = copy.deepcopy(arg_value)
+            else:
+                snapshot[key] = copy.deepcopy(value)
+        return snapshot
+
+    def _get_unfinished_runs_from_primary_cache(self):
+        with self.unfinished_runs_lock:
+            run_ids = list(self.unfinished_runs)
+
+        unfinished_runs = []
+        for run_id in run_ids:
+            run = self.get_run(run_id)
+            if run is None:
+                continue
+            with self.active_run_lock(run_id):
+                if run["finished"]:
+                    continue
+                snapshot = self._snapshot_unfinished_run(run)
+            if not self._has_valid_results(snapshot):
+                continue
+            unfinished_runs.append(snapshot)
+
+        earliest_time = datetime.min.replace(tzinfo=UTC)
+        unfinished_runs.sort(
+            key=lambda run: run.get("last_updated") or earliest_time,
+            reverse=True,
+        )
+        return unfinished_runs
+
+    @lru_cache(maxsize=1, expiration=5, refresh=False)
+    def _get_unfinished_runs_from_db(self):
+        projection = {"tasks": 0, "bad_tasks": 0, "args.spsa.param_history": 0}
+        return list(
+            self.runs.find(
+                {"finished": False},
+                projection,
+                sort=[("last_updated", DESCENDING)],
+            )
+        )
+
+    @staticmethod
+    def _has_valid_results(run):
+        results = run.get("results")
+        return isinstance(results, dict) and {"wins", "losses", "draws"}.issubset(
+            results
+        )
+
     def get_unfinished_runs(self, username=None):
         # Note: the result can be only used once.
 
-        unfinished_runs = self.runs.find({"finished": False}, {"_id": 1, "tasks": 0})
+        if self.__is_primary_instance:
+            unfinished_runs = iter(self._get_unfinished_runs_from_primary_cache())
+        else:
+            unfinished_runs = (
+                self._snapshot_unfinished_run(run)
+                for run in self._get_unfinished_runs_from_db()
+                if self._has_valid_results(run)
+            )
         if username:
             unfinished_runs = (
                 r for r in unfinished_runs if r["args"].get("username") == username

--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -11,6 +11,7 @@ from pymongo import DESCENDING
 
 from fishtest.api import WORKER_VERSION
 from fishtest.run_cache import Prio
+from fishtest.rundb import RunDb
 from fishtest.spsa_handler import _pack_flips, _unpack_flips
 
 
@@ -142,6 +143,67 @@ class CreateRunDBTest(unittest.TestCase):
         for run in self.rundb.get_unfinished_runs():
             if run["args"]["username"] == "TestRunDbUser":
                 print(run["args"])
+
+    def test_11_get_unfinished_runs_primary_returns_detached_snapshots(self):
+        run_id = self._create_test_run()
+        run = self.rundb.get_run(run_id)
+        run["results"]["wins"] = 11
+        run["results"]["losses"] = 7
+        run["args"]["spsa"] = {
+            "iter": 2,
+            "num_iter": 10,
+            "param_history": [{"theta": 1.0}],
+        }
+        run["bad_tasks"] = [{"task_id": 0}]
+        self.rundb.buffer(run, priority=Prio.SAVE_NOW)
+
+        snapshot = next(
+            run
+            for run in self.rundb.get_unfinished_runs(username="TestRunDbUser")
+            if str(run["_id"]) == run_id
+        )
+
+        self.assertNotIn("tasks", snapshot)
+        self.assertNotIn("bad_tasks", snapshot)
+        self.assertEqual(snapshot["args"]["spsa"]["param_history"], [])
+
+        snapshot["results"]["wins"] = 999
+        snapshot["args"]["info"] = "mutated"
+
+        live_run = self.rundb.get_run(run_id)
+        self.assertEqual(live_run["results"]["wins"], 11)
+        self.assertEqual(live_run["args"]["info"], "The ultimate patch")
+        self.assertEqual(
+            live_run["args"]["spsa"]["param_history"],
+            [{"theta": 1.0}],
+        )
+        self.assertIn("tasks", live_run)
+        self.assertIn("bad_tasks", live_run)
+
+    def test_12_get_unfinished_runs_secondary_omits_heavy_fields(self):
+        run_id = self._create_test_run()
+        run = self.rundb.get_run(run_id)
+        run["args"]["spsa"] = {
+            "iter": 3,
+            "num_iter": 12,
+            "param_history": [{"theta": 1.5}],
+        }
+        run["bad_tasks"] = [{"task_id": 1}]
+        self.rundb.buffer(run, priority=Prio.SAVE_NOW)
+
+        secondary = RunDb(db_name=self.rundb.db.name, is_primary_instance=False)
+        self.addCleanup(secondary.conn.close)
+
+        snapshot = next(
+            run
+            for run in secondary.get_unfinished_runs(username="TestRunDbUser")
+            if str(run["_id"]) == run_id
+        )
+
+        self.assertEqual(str(snapshot["_id"]), run_id)
+        self.assertNotIn("tasks", snapshot)
+        self.assertNotIn("bad_tasks", snapshot)
+        self.assertEqual(snapshot["args"]["spsa"]["param_history"], [])
 
     def test_20_update_task(self):
         run_id = self._create_test_run()


### PR DESCRIPTION
Serve stripped unfinished-run snapshots from authoritative in-memory state on primaries and from a projected five-second DB snapshot on secondaries.  Keep the same-route /tests and /tests/user live polling contract unchanged while removing repeated heavy unfinished-run fetches from the run-table path.

Apply a symmetric result-validation guard on both primary and secondary paths so aggregate_unfinished_runs never encounters runs with incomplete results.

Add focused RunDb tests for detached primary snapshots and stripped secondary snapshots, and sync the template docs with the live behavior.