### PR TITLE
refactor(views): narrow UI routes to explicit HTTP methods

### DIFF
--- a/docs/4-ui-reference.md
+++ b/docs/4-ui-reference.md
@@ -26,7 +26,7 @@ Config keys:
 | `renderer` | string | Jinja2 template name (e.g., `"tests.html.j2"`) |
 | `require_csrf` | bool | Enforce CSRF validation on POST |
 | `require_primary` | bool | Reject POST on non-primary instance (503) |
-| `request_method` | string or tuple | Allowed HTTP methods (default: GET + POST) |
+| `request_method` | string or tuple | Allowed HTTP methods (default: GET) |
 | `http_cache` | int | `Cache-Control: max-age=` seconds |
 | `direct` | bool | Bypass `_dispatch_view` (for pure redirects) |
 
@@ -34,42 +34,49 @@ At module load time, `_register_view_routes()` iterates over `_VIEW_ROUTES`,
 wraps each handler with `_dispatch_view()` (unless `direct=True`), and
 registers it on the FastAPI router.
 
+When `request_method` is omitted, the route is read-only and registered as
+`GET` only. The small set of endpoints that render a form on `GET` and process
+it on `POST` opt into `GET, POST` explicitly, while pure mutations stay
+`POST` only. `HEAD` works on `GET` routes through middleware compatibility,
+but generic `OPTIONS` is not part of the UI route contract and returns `405`.
+
 ## Registered routes
 
 | Path | Method(s) | Handler | Template | Notes |
 |------|-----------|---------|----------|-------|
-| `/` | GET, POST | `home` | -- | Redirects to `/tests` (direct) |
+| `/` | GET | `home` | -- | Redirects to `/tests` (direct) |
 | `/login` | GET, POST | `login` | `login.html.j2` | CSRF |
 | `/logout` | POST | `logout` | -- | CSRF |
 | `/signup` | GET, POST | `signup` | `signup.html.j2` | CSRF |
-| `/tests` | GET, POST | `tests` | `tests.html.j2` | Main dashboard; page 1 live run tables poll the same route via `?live=run_tables` |
+| `/tests` | GET | `tests` | `tests.html.j2` | Main dashboard; page 1 live run tables poll the same route via `?live=run_tables` |
 | `/tests/run` | GET, POST | `tests_run` | `tests_run.html.j2` | CSRF, primary |
 | `/tests/modify` | POST | `tests_modify` | -- | CSRF, primary |
 | `/tests/stop` | POST | `tests_stop` | -- | CSRF, primary |
 | `/tests/approve` | POST | `tests_approve` | -- | CSRF, primary |
 | `/tests/purge` | POST | `tests_purge` | -- | CSRF, primary |
 | `/tests/delete` | POST | `tests_delete` | -- | CSRF, primary |
-| `/tests/view/{id}` | GET, POST | `tests_view` | `tests_view.html.j2` | Full detail page; unfinished runs poll the merged detail fragment endpoint and the dedicated tasks endpoint |
-| `/tests/view/{id}/detail` | GET, POST | `tests_view_detail` | `tests_view_detail_fragment.html.j2` | Fragment-only; OOB refresh for ELO, run status, active-worker totals, detail, time, chi-square, and the retained SPSA data payload |
-| `/tests/live_elo/{id}` | GET, POST | `tests_live_elo` | `tests_live_elo.html.j2` | Live Elo page + dual-scale gauge |
-| `/tests/stats/{id}` | GET, POST | `tests_stats` | `tests_stats.html.j2` | HX: `tests_stats_content_fragment.html.j2`; active runs poll with the dedicated stats-page interval and visibility-aware refresh |
-| `/tests/tasks/{id}` | GET, POST | `tests_tasks` | `tasks_content_fragment.html.j2` | Fragment-only; updates the scrolling task table body and refreshes fixed controls/pagination OOB, with server-side sorting for every visible task column, one combined worker/info search filter, and 25-row pagination |
-| `/tests/machines` | GET, POST | `tests_machines` | `machines_fragment.html.j2` | Fragment-only, 10s cache |
-| `/tests/live_elo_update/{id}` | GET, POST | `live_elo_update` | `live_elo_fragment.html.j2` | Fragment-only (OOB) |
-| `/tests/finished` | GET, POST | `tests_finished` | `tests_finished.html.j2` | HX: `tests_finished_content_fragment` |
-| `/tests/user/{username}` | GET, POST | `tests_user` | `tests_user.html.j2` | HX: `tests_user_content_fragment`; page 1 live run tables poll the same route via `?live=run_tables` |
-| `/actions` | GET, POST | `actions` | `actions.html.j2` | HX: `actions_content_fragment` |
-| `/contributors` | GET, POST | `contributors` | `contributors.html.j2` | HX: `contributors_content_fragment`; paginated (100/page) |
-| `/contributors/monthly` | GET, POST | `contributors_monthly` | `contributors.html.j2` | HX: `contributors_content_fragment`; paginated (100/page) |
+| `/tests/view/{id}` | GET | `tests_view` | `tests_view.html.j2` | Full detail page; unfinished runs poll the merged detail fragment endpoint and the dedicated tasks endpoint |
+| `/tests/view/{id}/detail` | GET | `tests_view_detail` | `tests_view_detail_fragment.html.j2` | Fragment-only; OOB refresh for ELO, run status, active-worker totals, detail, time, chi-square, and the retained SPSA data payload |
+| `/tests/live_elo/{id}` | GET | `tests_live_elo` | `tests_live_elo.html.j2` | Live Elo page + dual-scale gauge |
+| `/tests/stats/{id}` | GET | `tests_stats` | `tests_stats.html.j2` | HX: `tests_stats_content_fragment.html.j2`; active runs poll with the dedicated stats-page interval and visibility-aware refresh |
+| `/tests/tasks/{id}` | GET | `tests_tasks` | `tasks_content_fragment.html.j2` | Fragment-only; updates the scrolling task table body and refreshes fixed controls/pagination OOB, with server-side sorting for every visible task column, one combined worker/info search filter, and 25-row pagination |
+| `/tests/machines` | GET | `tests_machines` | `machines_fragment.html.j2` | Fragment-only, 10s cache |
+| `/tests/live_elo_update/{id}` | GET | `live_elo_update` | `live_elo_fragment.html.j2` | Fragment-only (OOB) |
+| `/tests/finished` | GET | `tests_finished` | `tests_finished.html.j2` | HX: `tests_finished_content_fragment` |
+| `/tests/user/{username}` | GET | `tests_user` | `tests_user.html.j2` | HX: `tests_user_content_fragment`; page 1 live run tables poll the same route via `?live=run_tables` |
+| `/actions` | GET | `actions` | `actions.html.j2` | HX: `actions_content_fragment` |
+| `/contributors` | GET | `contributors` | `contributors.html.j2` | HX: `contributors_content_fragment`; paginated (100/page) |
+| `/contributors/monthly` | GET | `contributors_monthly` | `contributors.html.j2` | HX: `contributors_content_fragment`; paginated (100/page) |
 | `/user/{username}` | GET, POST | `user` | `user.html.j2` | |
 | `/user` | GET, POST | `user` | `user.html.j2` | |
-| `/user_management` | GET, POST | `user_management` | `user_management.html.j2` | HX: `user_management_content_fragment` |
+| `/user_management` | GET | `user_management` | `user_management.html.j2` | HX: `user_management_content_fragment` |
+| `/user_management/pending_count` | GET | `user_management_pending_count` | `pending_users_nav_fragment.html.j2` | Fragment-only sidebar poll |
 | `/workers/{worker_name}` | GET, POST | `workers` | `workers.html.j2` | CSRF; HX: `workers_content_fragment` |
 | `/upload` | GET, POST | `upload` | `nn_upload.html.j2` | CSRF |
-| `/nns` | GET, POST | `nns` | `nns.html.j2` | HX: `nns_content_fragment` |
-| `/sprt_calc` | GET, POST | `sprt_calc` | `sprt_calc.html.j2` | |
-| `/rate_limits` | GET, POST | `rate_limits` | `rate_limits.html.j2` | |
-| `/rate_limits/server` | GET, POST | `rate_limits_server` | inline HTML response | Fragment-only |
+| `/nns` | GET | `nns` | `nns.html.j2` | HX: `nns_content_fragment` |
+| `/sprt_calc` | GET | `sprt_calc` | `sprt_calc.html.j2` | |
+| `/rate_limits` | GET | `rate_limits` | `rate_limits.html.j2` | |
+| `/rate_limits/server` | GET | `rate_limits_server` | inline HTML response | Fragment-only |
 
 ## Sidebar status links
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -3646,9 +3646,21 @@ _VIEW_ROUTES: list[_ViewRoute] = [
     (
         workers,
         "/workers/{worker_name}",
-        {"renderer": "workers.html.j2", "require_csrf": True},
+        {
+            "renderer": "workers.html.j2",
+            "require_csrf": True,
+            "request_method": ("GET", "POST"),
+        },
     ),
-    (upload, "/upload", {"renderer": "nn_upload.html.j2", "require_csrf": True}),
+    (
+        upload,
+        "/upload",
+        {
+            "renderer": "nn_upload.html.j2",
+            "require_csrf": True,
+            "request_method": ("GET", "POST"),
+        },
+    ),
     (logout, "/logout", {"require_csrf": True, "request_method": "POST"}),
     (
         signup,
@@ -3670,8 +3682,16 @@ _VIEW_ROUTES: list[_ViewRoute] = [
     ),
     (actions, "/actions", {"renderer": "actions.html.j2"}),
     (user_management, "/user_management", {"renderer": "user_management.html.j2"}),
-    (user, "/user/{username}", {"renderer": "user.html.j2"}),
-    (user, "/user", {"renderer": "user.html.j2"}),
+    (
+        user,
+        "/user/{username}",
+        {"renderer": "user.html.j2", "request_method": ("GET", "POST")},
+    ),
+    (
+        user,
+        "/user",
+        {"renderer": "user.html.j2", "request_method": ("GET", "POST")},
+    ),
     (contributors, "/contributors", {"renderer": "contributors.html.j2"}),
     (
         contributors_monthly,
@@ -3685,6 +3705,7 @@ _VIEW_ROUTES: list[_ViewRoute] = [
             "renderer": "tests_run.html.j2",
             "require_csrf": True,
             "require_primary": True,
+            "request_method": ("GET", "POST"),
         },
     ),
     (
@@ -3758,7 +3779,7 @@ def _make_endpoint(
 
 def _normalize_methods(methods: _RouteMethods | None) -> list[str]:
     if methods is None:
-        return ["GET", "POST"]
+        return ["GET"]
     if isinstance(methods, str):
         return [methods]
     return list(methods)

--- a/server/tests/test_views_routes.py
+++ b/server/tests/test_views_routes.py
@@ -1,0 +1,145 @@
+# ruff: noqa: ANN201, ANN206, D100, D101, D102, INP001, PT009
+"""Test UI route HTTP method contracts."""
+
+import unittest
+
+import test_support
+
+_GET_ONLY_ROUTES = {
+    "/",
+    "/actions",
+    "/contributors",
+    "/contributors/monthly",
+    "/nns",
+    "/rate_limits",
+    "/rate_limits/server",
+    "/sprt_calc",
+    "/tests",
+    "/tests/finished",
+    "/tests/live_elo/{id}",
+    "/tests/live_elo_update/{id}",
+    "/tests/machines",
+    "/tests/stats/{id}",
+    "/tests/tasks/{id}",
+    "/tests/user/{username}",
+    "/tests/view/{id}",
+    "/tests/view/{id}/detail",
+    "/user_management",
+    "/user_management/pending_count",
+}
+
+_DUAL_METHOD_ROUTES = {
+    "/login",
+    "/signup",
+    "/tests/run",
+    "/upload",
+    "/user",
+    "/user/{username}",
+    "/workers/{worker_name}",
+}
+
+_POST_ONLY_ROUTES = {
+    "/logout",
+    "/tests/approve",
+    "/tests/delete",
+    "/tests/modify",
+    "/tests/purge",
+    "/tests/stop",
+}
+
+
+class TestViewRouteMethods(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _FastAPI, cls.TestClient = test_support.require_fastapi()
+        try:
+            from fastapi.routing import APIRoute
+
+            from fishtest.views import _VIEW_ROUTES
+        except ModuleNotFoundError as exc:  # pragma: no cover
+            raise unittest.SkipTest(
+                f"Server dependencies missing ({exc.name}); skipping FastAPI HTTP tests",
+            )
+
+        cls.APIRoute = APIRoute
+        cls.declared_view_paths = {path for _fn, path, _cfg in _VIEW_ROUTES}
+        cls.rundb = test_support.get_rundb()
+
+    @classmethod
+    def tearDownClass(cls):
+        test_support.cleanup_test_rundb(cls.rundb)
+
+    def _build_client(self):
+        return test_support.make_test_client(
+            rundb=self.rundb,
+            include_api=False,
+            include_views=True,
+        )
+
+    def _route_methods(self):
+        app = test_support.build_test_app(
+            rundb=self.rundb,
+            include_api=False,
+            include_views=True,
+        )
+        route_methods = {
+            route.path: set(route.methods or set())
+            for route in app.routes
+            if isinstance(route, self.APIRoute)
+            and route.path in self.declared_view_paths
+        }
+        self.assertSetEqual(set(route_methods), self.declared_view_paths)
+        return route_methods
+
+    def test_registered_ui_route_methods_match_contract(self):
+        expected_paths = _GET_ONLY_ROUTES | _DUAL_METHOD_ROUTES | _POST_ONLY_ROUTES
+        expected = {path: {"GET"} for path in _GET_ONLY_ROUTES}
+        expected.update({path: {"GET", "POST"} for path in _DUAL_METHOD_ROUTES})
+        expected.update({path: {"POST"} for path in _POST_ONLY_ROUTES})
+
+        self.assertSetEqual(self.declared_view_paths, expected_paths)
+        self.assertEqual(self._route_methods(), expected)
+
+    def test_get_only_ui_route_rejects_post(self):
+        client = self._build_client()
+
+        response = client.post("/tests")
+
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.headers.get("allow"), "GET")
+
+    def test_get_only_ui_route_still_accepts_head(self):
+        client = self._build_client()
+
+        response = client.head("/tests")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
+
+    def test_options_is_not_part_of_ui_route_contract(self):
+        client = self._build_client()
+
+        response = client.options("/tests")
+
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.headers.get("allow"), "GET")
+
+    def test_login_route_still_accepts_post(self):
+        client = self._build_client()
+
+        response = client.get("/login")
+        self.assertEqual(response.status_code, 200)
+        csrf = test_support.extract_csrf_token(response.text)
+
+        response = client.post(
+            "/login",
+            data={
+                "username": "route-method-user",
+                "password": "wrong-password",
+                "csrf_token": csrf,
+            },
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Invalid username or password.", response.text)


### PR DESCRIPTION
Default UI routes to GET and opt only the real form handlers into GET and POST. Keep mutation endpoints POST-only, add route-contract regression tests, and align the UI reference with the live method surface.

Preserve middleware-backed HEAD behavior for read routes and keep generic OPTIONS outside the current UI contract.