### PR TITLE
fix(server): restore unfinished-run monthly contributor accounting

### DIFF
--- a/docs/4-ui-reference.md
+++ b/docs/4-ui-reference.md
@@ -630,8 +630,8 @@ Behavior notes:
    pagination/sort/view links, preventing repeated jumps during later browsing.
 - `/contributors` and `/contributors/monthly` stay on the userdb fast path:
    the all-time page reads from `userdb.user_cache`, and the monthly page reads
-   from `userdb.top_month`, so search and rank-jump never need an actions-log
-   scan.
+   from `userdb.top_month`, a rolling cache rebuilt from active unfinished runs
+   plus finished runs started within the last 30 days.
 - Sort-header links are dual-mode (`href` + `hx-get`): contributors sorting
    swaps `#contributors-content` with `hx-push-url="true"` when htmx is active,
    and still works as normal navigation when JavaScript is unavailable.

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -63,6 +63,19 @@ from fishtest.util import (
 )
 from fishtest.workerdb import WorkerDb
 
+_UNFINISHED_RUNS_LIGHTWEIGHT_PROJECTION = {"_id": 1, "tasks": 0}
+
+_UNFINISHED_RUNS_STATS_PROJECTION = {
+    "_id": 1,
+    "args.username": 1,
+    "args.tc": 1,
+    "args.threads": 1,
+    "tasks.worker_info.username": 1,
+    "tasks.last_updated": 1,
+    "tasks.num_games": 1,
+    "tasks.stats": 1,
+}
+
 
 class RunDb:
     def __init__(self, db_name=FISHTEST, port=-1, is_primary_instance=True):
@@ -847,15 +860,27 @@ class RunDb:
         )
         return unfinished_runs
 
+    @staticmethod
+    def _filter_unfinished_runs_by_username(unfinished_runs, username):
+        if username:
+            return (r for r in unfinished_runs if r["args"].get("username") == username)
+        return unfinished_runs
+
     def get_unfinished_runs(self, username=None):
         # Note: the result can be only used once.
 
-        unfinished_runs = self.runs.find({"finished": False}, {"_id": 1, "tasks": 0})
-        if username:
-            unfinished_runs = (
-                r for r in unfinished_runs if r["args"].get("username") == username
-            )
-        return unfinished_runs
+        unfinished_runs = self.runs.find(
+            {"finished": False}, _UNFINISHED_RUNS_LIGHTWEIGHT_PROJECTION
+        )
+        return self._filter_unfinished_runs_by_username(unfinished_runs, username)
+
+    def get_unfinished_runs_for_stats(self, username=None):
+        # Note: the result can be only used once.
+
+        unfinished_runs = self.runs.find(
+            {"finished": False}, _UNFINISHED_RUNS_STATS_PROJECTION
+        )
+        return self._filter_unfinished_runs_by_username(unfinished_runs, username)
 
     @lru_cache(maxsize=1, expiration=5, refresh=False)
     def _get_machine_runs_from_db(self):

--- a/server/tests/test_delta_update_users.py
+++ b/server/tests/test_delta_update_users.py
@@ -1,0 +1,94 @@
+"""Test monthly contributor stats rebuild helpers."""
+
+import copy
+import unittest
+from datetime import UTC, datetime
+
+from utils import delta_update_users
+
+
+def _user_stats(username):
+    return {
+        "username": username,
+        "cpu_hours": 0.0,
+        "games": 0,
+        "games_per_hour": 0.0,
+        "tests": 0,
+        "tests_repo": "",
+        "last_updated": datetime.min.replace(tzinfo=UTC),
+    }
+
+
+class _FakeRunsCollection:
+    def find(self, *_args, **_kwargs):
+        return []
+
+
+class _FakeRunDb:
+    def __init__(self, unfinished_runs):
+        self._unfinished_runs = unfinished_runs
+        self.get_unfinished_runs_called = False
+        self.get_unfinished_runs_for_stats_called = False
+        self.runs = _FakeRunsCollection()
+
+    def get_unfinished_runs(self):
+        self.get_unfinished_runs_called = True
+        return iter([])
+
+    def get_unfinished_runs_for_stats(self):
+        self.get_unfinished_runs_for_stats_called = True
+        return iter(self._unfinished_runs)
+
+
+class DeltaUpdateUsersTest(unittest.TestCase):
+    def test_process_run_requires_tasks(self):
+        info = {"run-author": _user_stats("run-author")}
+        run = {
+            "_id": "unfinished-run",
+            "args": {"username": "run-author", "tc": "10+0.1", "threads": 1},
+        }
+
+        with self.assertRaises(KeyError):
+            delta_update_users.process_run(run, info)
+
+    def test_update_info_uses_stats_reader_for_unfinished_runs(self):
+        last_updated = datetime.now(UTC)
+        run = {
+            "_id": "unfinished-run",
+            "args": {"username": "run-author", "tc": "10+0.1", "threads": 1},
+            "tasks": [
+                {
+                    "worker_info": {"username": "worker-user"},
+                    "stats": {"wins": 2, "losses": 1, "draws": 3},
+                    "last_updated": last_updated,
+                    "num_games": 6,
+                }
+            ],
+        }
+        rundb = _FakeRunDb([run])
+        info_total = {
+            "run-author": _user_stats("run-author"),
+            "worker-user": _user_stats("worker-user"),
+        }
+        info_top_month = copy.deepcopy(info_total)
+
+        new_deltas = delta_update_users.update_info(
+            rundb,
+            {},
+            info_total,
+            info_top_month,
+            clear_stats=True,
+        )
+
+        self.assertEqual(new_deltas, {})
+        self.assertTrue(rundb.get_unfinished_runs_for_stats_called)
+        self.assertFalse(rundb.get_unfinished_runs_called)
+        self.assertEqual(info_total["run-author"]["tests"], 0)
+        self.assertEqual(info_top_month["run-author"]["tests"], 1)
+        self.assertEqual(info_top_month["worker-user"]["games"], 6)
+        self.assertEqual(info_top_month["worker-user"]["last_updated"], last_updated)
+        self.assertGreater(info_top_month["worker-user"]["cpu_hours"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -143,6 +143,61 @@ class CreateRunDBTest(unittest.TestCase):
             if run["args"]["username"] == "TestRunDbUser":
                 print(run["args"])
 
+    def test_11_get_unfinished_runs_keeps_default_projection_lightweight(self):
+        run_id = self._create_test_run()
+        run = self.rundb.get_run(run_id)
+        run["tasks"][0]["worker_info"] = self.worker_info
+        run["tasks"][0]["last_updated"] = datetime.now(UTC)
+        run["tasks"][0]["stats"] = {
+            "wins": 1,
+            "draws": self.chunk_size - 2,
+            "losses": 1,
+            "crashes": 0,
+        }
+        run["workers"] = run["cores"] = 1
+        self.rundb.buffer(run, priority=Prio.SAVE_NOW)
+
+        unfinished_run = next(
+            run for run in self.rundb.get_unfinished_runs() if str(run["_id"]) == run_id
+        )
+
+        self.assertNotIn("tasks", unfinished_run)
+
+    def test_12_get_unfinished_runs_for_stats_returns_task_projection(self):
+        run_id = self._create_test_run()
+        run = self.rundb.get_run(run_id)
+        run["tasks"][0]["worker_info"] = self.worker_info
+        run["tasks"][0]["last_updated"] = datetime.now(UTC)
+        run["tasks"][0]["stats"] = {
+            "wins": 2,
+            "draws": self.chunk_size - 4,
+            "losses": 2,
+            "crashes": 0,
+        }
+        run["workers"] = run["cores"] = 1
+        self.rundb.buffer(run, priority=Prio.SAVE_NOW)
+
+        unfinished_run = next(
+            run
+            for run in self.rundb.get_unfinished_runs_for_stats()
+            if str(run["_id"]) == run_id
+        )
+
+        self.assertIn("tasks", unfinished_run)
+        self.assertNotIn("results", unfinished_run)
+        self.assertEqual(
+            set(unfinished_run["args"].keys()),
+            {"username", "tc", "threads"},
+        )
+        self.assertEqual(
+            unfinished_run["tasks"][0]["worker_info"],
+            {"username": self.worker_info["username"]},
+        )
+        self.assertIn("last_updated", unfinished_run["tasks"][0])
+        self.assertIn("num_games", unfinished_run["tasks"][0])
+        self.assertIn("stats", unfinished_run["tasks"][0])
+        self.assertNotIn("active", unfinished_run["tasks"][0])
+
     def test_20_update_task(self):
         run_id = self._create_test_run()
         run = self.rundb.get_run(run_id)

--- a/server/utils/delta_update_users.py
+++ b/server/utils/delta_update_users.py
@@ -128,7 +128,7 @@ def process_run(run: dict, info: dict) -> None:
 
     # Update the information for the workers contributed by the users
     tc = estimate_game_duration(run["args"]["tc"])
-    for task in run.get("tasks", {}):
+    for task in run["tasks"]:
         if "worker_info" not in task:
             continue
         t_username = task["worker_info"].get("username")
@@ -181,7 +181,7 @@ def update_info(
         dict: New deltas containing newly processed run IDs.
 
     """
-    for run in rundb.get_unfinished_runs():
+    for run in rundb.get_unfinished_runs_for_stats():
         try:
             # Update info_top_month with the contribution of the unfinished run
             process_run(run, info_top_month)


### PR DESCRIPTION
Keep the default unfinished-run query lightweight for the UI path and add a dedicated stats-only reader that returns the narrow task-bearing projection required by the monthly contributor rebuild.

Use that reader in delta_update_users so active unfinished runs again contribute worker games and CPU hours to the monthly contributors cache, and make missing task data fail loudly instead of being treated as zero work.

Add regression coverage for the lightweight UI projection, the new stats-only projection, and the monthly rebuild helper contract. Update the contributors references to describe the restored monthly data flow.