### PR TITLE
fix(tests_repo): canonicalize stored GitHub repo URLs

### DIFF
--- a/docs/4-ui-reference.md
+++ b/docs/4-ui-reference.md
@@ -98,6 +98,25 @@ Route notes:
   is present, otherwise renders the full-page template.
 - **OOB**: fragment contains `hx-swap-oob` attributes for multi-element updates.
 
+## Tests Repository URL Contract
+
+The `Tests Repository` field used on `/signup`, `/user`, and `/tests/run`
+accepts a GitHub repository URL with or without a trailing slash.
+
+Server-side behavior:
+
+- validation still accepts either `https://github.com/<user>/<repo>` or
+   `https://github.com/<user>/<repo>/`
+- stored user profile data is canonicalized to the slash-free form
+- stored run data uses the slash-free form in `run["args"]["tests_repo"]`
+
+Canonical stored value:
+
+- `https://github.com/<user>/<repo>`
+
+This keeps GitHub compare links and worker download URLs stable even when the
+submitted form value includes a trailing slash.
+
 ## `/tests/view/{id}/detail` live detail contract
 
 The test detail page keeps its live summary and detail data synchronized

--- a/docs/4-ui-reference.md
+++ b/docs/4-ui-reference.md
@@ -107,8 +107,10 @@ Server-side behavior:
 
 - validation still accepts either `https://github.com/<user>/<repo>` or
    `https://github.com/<user>/<repo>/`
-- stored user profile data is canonicalized to the slash-free form
-- stored run data uses the slash-free form in `run["args"]["tests_repo"]`
+- newly created or updated user profile data is canonicalized to the
+   slash-free form
+- newly created run data uses the slash-free form in
+   `run["args"]["tests_repo"]`
 
 Canonical stored value:
 

--- a/docs/5-templates.md
+++ b/docs/5-templates.md
@@ -40,7 +40,7 @@ and `http/jinja.py`.
 | `results_pre_attrs(...)` | `template_helpers.py` | HTML attributes for results display (returns `Markup`) |
 | `run_tables_prefix(username)` | `template_helpers.py` | Toggle prefix for run tables |
 | `tests_run_setup(...)` | `template_helpers.py` | Test form default values |
-| `tests_repo(run)` | `util.py` | Extract tests repo URL from run |
+| `tests_repo(run)` | `util.py` | Extract the canonical tests repo URL from run |
 | `worker_name(info)` | `util.py` | Format worker name from info dict |
 | `list_to_string(values, decimals)` | `template_helpers.py` | Formats a list of floats as a string |
 | `pdf_to_string(...)` | `template_helpers.py` | Formats a probability density function |
@@ -611,6 +611,12 @@ Rendered structure notes:
 - the collapsed preset blocks expose stable ids so the toggle button can name
    them through `aria-controls`.
 
+Tests repository contract:
+
+- `tests_repo_value` is rendered as the canonical GitHub repo URL for the form
+- trailing-slash input is accepted on submit, but stored runs use the
+  slash-free form
+
 ### `tests_stats.html.j2`
 
 Page shell for `/tests/stats/{id}`. Includes the shared stats content fragment and,
@@ -817,6 +823,12 @@ Rendered structure:
 | `form_action` | URL |
 | `registration_time_label` | string |
 | `blocked` | bool |
+
+Tests repository contract:
+
+- `user["tests_repo"]` is persisted as the canonical slash-free GitHub repo URL
+- profile form submissions may include a trailing slash, but stored user data
+   is normalized before save
 
 ### `user_management.html.j2`
 

--- a/docs/5-templates.md
+++ b/docs/5-templates.md
@@ -613,9 +613,10 @@ Rendered structure notes:
 
 Tests repository contract:
 
-- `tests_repo_value` is rendered as the canonical GitHub repo URL for the form
-- trailing-slash input is accepted on submit, but stored runs use the
-  slash-free form
+- `tests_repo_value` is rendered from the current GitHub repo value for the
+   form
+- trailing-slash input is accepted on submit, but newly stored runs use the
+   slash-free form
 
 ### `tests_stats.html.j2`
 

--- a/server/fishtest/github_api.py
+++ b/server/fishtest/github_api.py
@@ -113,6 +113,7 @@ def init(kvstore, actiondb, *, refresh_master_sha=True):
 
 def clear_api_cache():
     _lru_cache.clear()
+    normalize_repo.cache_clear()
 
 
 def save():
@@ -428,7 +429,12 @@ def get_master_repo(
             r = r["parent"]
 
 
-@lru_cache(maxsize=128, expiration=600, refresh=False)
+@lru_cache(
+    maxsize=128,
+    expiration=600,
+    refresh=False,
+    key=lambda f, args, kw: (f.__name__, canonicalize_repo_url(args[0])),
+)
 def normalize_repo(repo):
     repo = canonicalize_repo_url(repo)
     r = call(

--- a/server/fishtest/github_api.py
+++ b/server/fishtest/github_api.py
@@ -329,6 +329,17 @@ def parse_repo(repo_url):
     return (p[1], p[2])
 
 
+def canonicalize_repo_url(repo_url: str | None) -> str | None:
+    if not repo_url:
+        return repo_url
+
+    parsed = urlparse(repo_url)
+    if not parsed.path.endswith("/"):
+        return repo_url
+
+    return parsed._replace(path=parsed.path.rstrip("/")).geturl()
+
+
 def get_merge_base_commit(
     user1="official-stockfish",
     sha1=None,
@@ -419,6 +430,7 @@ def get_master_repo(
 
 @lru_cache(maxsize=128, expiration=600, refresh=False)
 def normalize_repo(repo):
+    repo = canonicalize_repo_url(repo)
     r = call(
         repo,
         _method="HEAD",
@@ -427,7 +439,7 @@ def normalize_repo(repo):
         _ignore_rate_limit=True,
     )
     r.raise_for_status()
-    return r.url
+    return canonicalize_repo_url(r.url)
 
 
 def compare_branches_url(

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -608,7 +608,7 @@ class RunDb:
             "base_signature": base_signature,
             "new_signature": new_signature,
             "username": username,
-            "tests_repo": tests_repo,
+            "tests_repo": gh.canonicalize_repo_url(tests_repo),
             "auto_purge": auto_purge,
             "throughput": throughput,
             "itp": 100,  # internal throughput

--- a/server/fishtest/userdb.py
+++ b/server/fishtest/userdb.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from pymongo import ASCENDING
 from vtjson import ValidationError, validate
 
+import fishtest.github_api as gh
 from fishtest.lru_cache import lru_cache
 from fishtest.schemas import user_schema
 
@@ -129,7 +130,7 @@ class UserDb:
                 "blocked": False,
                 "email": email,
                 "groups": [],
-                "tests_repo": tests_repo,
+                "tests_repo": gh.canonicalize_repo_url(tests_repo),
                 "machine_limit": DEFAULT_MACHINE_LIMIT,
             }
             validate_user(user)
@@ -141,6 +142,8 @@ class UserDb:
             return None
 
     def save_user(self, user):
+        if "tests_repo" in user:
+            user["tests_repo"] = gh.canonicalize_repo_url(user["tests_repo"])
         validate_user(user)
         self.users.replace_one({"_id": user["_id"]}, user)
         self.clear_cache()

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -576,7 +576,7 @@ def count_games(stats):
 
 
 def tests_repo(run):
-    tests_repo = run["args"]["tests_repo"]
+    tests_repo = gh.canonicalize_repo_url(run["args"]["tests_repo"])
     if tests_repo != "":
         return tests_repo
     else:

--- a/server/tests/test_github_api.py
+++ b/server/tests/test_github_api.py
@@ -262,6 +262,30 @@ class RepoCanonicalizationTests(unittest.TestCase):
         )
         response.raise_for_status.assert_called_once_with()
 
+    def test_normalize_repo_cache_key_canonicalizes_trailing_slash(self):
+        response = mock.Mock()
+        response.url = self.repo_url
+
+        with mock.patch("fishtest.github_api.call", return_value=response) as call:
+            normalized_with_slash = gh.normalize_repo(self.repo_url + "/")
+            normalized_without_slash = gh.normalize_repo(self.repo_url)
+
+        self.assertEqual(normalized_with_slash, self.repo_url)
+        self.assertEqual(normalized_without_slash, self.repo_url)
+        self.assertEqual(call.call_count, 1)
+
+        key_with_slash = gh.normalize_repo.key(
+            gh.normalize_repo,
+            (self.repo_url + "/",),
+            {},
+        )
+        key_without_slash = gh.normalize_repo.key(
+            gh.normalize_repo,
+            (self.repo_url,),
+            {},
+        )
+        self.assertEqual(key_with_slash, key_without_slash)
+
 
 class GitHubApiRetryTests(unittest.TestCase):
     def _run_call_with_side_effect(self, side_effect):

--- a/server/tests/test_github_api.py
+++ b/server/tests/test_github_api.py
@@ -230,6 +230,39 @@ class GetShaRobustnessTests(unittest.TestCase):
         self.assertEqual(message, "")
 
 
+class RepoCanonicalizationTests(unittest.TestCase):
+    repo_url = "https://github.com/official-stockfish/Stockfish"
+
+    def tearDown(self):
+        gh.clear_api_cache()
+
+    def test_canonicalize_repo_url_strips_trailing_slash(self):
+        self.assertEqual(
+            gh.canonicalize_repo_url(self.repo_url + "/"),
+            self.repo_url,
+        )
+        self.assertEqual(gh.canonicalize_repo_url(self.repo_url), self.repo_url)
+        self.assertEqual(gh.canonicalize_repo_url(""), "")
+        self.assertIsNone(gh.canonicalize_repo_url(None))
+
+    def test_normalize_repo_returns_slash_free_url(self):
+        response = mock.Mock()
+        response.url = self.repo_url + "/"
+
+        with mock.patch("fishtest.github_api.call", return_value=response) as call:
+            normalized = gh.normalize_repo(self.repo_url + "/")
+
+        self.assertEqual(normalized, self.repo_url)
+        call.assert_called_once_with(
+            self.repo_url,
+            _method="HEAD",
+            timeout=gh.TIMEOUT,
+            allow_redirects=True,
+            _ignore_rate_limit=True,
+        )
+        response.raise_for_status.assert_called_once_with()
+
+
 class GitHubApiRetryTests(unittest.TestCase):
     def _run_call_with_side_effect(self, side_effect):
         old_initialized = gh._api_initialized

--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -83,7 +83,13 @@ class CreateRunDBTest(unittest.TestCase):
     def tearDown(self):
         self.rundb.runs.delete_many({"args.username": "TestRunDbUser"})
 
-    def _create_test_run(self, *, tc: str = "10+0.01", finished: bool = False) -> str:
+    def _create_test_run(
+        self,
+        *,
+        tc: str = "10+0.01",
+        finished: bool = False,
+        tests_repo: str = "https://github.com/15408be06cfa0ff6/Stockfish",
+    ) -> str:
         num_tasks = 4
         num_games = num_tasks * self.chunk_size
 
@@ -108,7 +114,7 @@ class CreateRunDBTest(unittest.TestCase):
             base_nets=["nn-0000000000a0.nnue"],
             new_nets=["nn-0000000000a0.nnue", "nn-0000000000a1.nnue"],
             rescheduled_from="653db116cc309ae839563103",
-            tests_repo="https://github.com/15408be06cfa0ff6/Stockfish",
+            tests_repo=tests_repo,
             auto_purge=False,
             username="TestRunDbUser",
             start_time=datetime.now(UTC),
@@ -253,6 +259,18 @@ class CreateRunDBTest(unittest.TestCase):
         self.assertEqual(
             unfinished_runs_for_stats[0]["args"]["username"],
             "TestRunDbUser",
+        )
+
+    def test_14_new_run_canonicalizes_tests_repo(self):
+        run_id = self._create_test_run(
+            tests_repo="https://github.com/15408be06cfa0ff6/Stockfish/",
+        )
+
+        run = self.rundb.get_run(run_id)
+
+        self.assertEqual(
+            run["args"]["tests_repo"],
+            "https://github.com/15408be06cfa0ff6/Stockfish",
         )
 
     def test_20_update_task(self):

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -136,6 +136,54 @@ class TestUsers(UiUserTestCase):
         self.assertTrue(response.headers.get("location", "").endswith("/login"))
         self._assert_no_store_headers(response)
 
+    def test_signup_canonicalizes_tests_repo(self):
+        signup_username = "TestCanonicalSignupUser"
+        self.rundb.userdb.users.delete_many({"username": signup_username})
+        self.rundb.userdb.clear_cache()
+        self.addCleanup(
+            self.rundb.userdb.users.delete_many,
+            {"username": signup_username},
+        )
+        self.addCleanup(self.rundb.userdb.clear_cache)
+
+        response = self.client.get("/signup")
+        self.assertEqual(response.status_code, 200)
+        csrf = test_support.extract_csrf_token(response.text)
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"FISHTEST_CAPTCHA_SECRET": "test-secret"},
+                clear=False,
+            ),
+            patch(
+                "fishtest.views.requests.post",
+                return_value=type(
+                    "_CaptchaResponse",
+                    (),
+                    {"json": staticmethod(lambda: {"success": True})},
+                )(),
+            ),
+        ):
+            response = self.client.post(
+                "/signup",
+                data={
+                    "username": signup_username,
+                    "password": self.signup_password,
+                    "password2": self.signup_password,
+                    "email": "canonical-signup-test@user.net",
+                    "tests_repo": self.tests_repo + "/",
+                    "g-recaptcha-response": "captcha-ok",
+                    "csrf_token": csrf,
+                },
+                follow_redirects=False,
+            )
+
+        self.assertEqual(response.status_code, 302)
+        created_user = self.rundb.userdb.get_user(signup_username)
+        self.assertIsNotNone(created_user)
+        self.assertEqual(created_user["tests_repo"], self.tests_repo)
+
     def test_signup_rejects_too_long_password(self):
         long_password = "A1!a" * 20
         self.assertGreater(len(long_password), PASSWORD_MAX_LENGTH)
@@ -307,6 +355,30 @@ class TestUsers(UiUserTestCase):
         updated_user = self.rundb.userdb.get_user(self.username)
         self.assertEqual(updated_user["email"], original_email)
         self.assertEqual(updated_user["tests_repo"], original_tests_repo)
+
+    def test_user_profile_post_canonicalizes_tests_repo(self):
+        self._login_user()
+        user = self.rundb.userdb.get_user(self.username)
+
+        response = self.client.get("/user")
+        self.assertEqual(response.status_code, 200)
+        csrf = test_support.extract_csrf_token(response.text)
+
+        response = self.client.post(
+            "/user",
+            data={
+                "user": self.username,
+                "old_password": self.password,
+                "email": user["email"],
+                "tests_repo": self.tests_repo + "/",
+                "csrf_token": csrf,
+            },
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        updated_user = self.rundb.userdb.get_user(self.username)
+        self.assertEqual(updated_user["tests_repo"], self.tests_repo)
 
     def test_user_admin_post_requires_csrf(self):
         target_username = self.signup_username

--- a/server/tests/test_views_helpers.py
+++ b/server/tests/test_views_helpers.py
@@ -7,6 +7,7 @@ detection, username matching, and heap-based merge behavior.
 import unittest
 from datetime import UTC, datetime
 
+from fishtest.util import tests_repo
 from fishtest.views_helpers import (
     _build_query_string,
     _clamp_page_index,
@@ -273,6 +274,26 @@ class IsHxRequestTests(unittest.TestCase):
             "R", (), {"headers": {"HX-Request": "true", "Sec-Fetch-Mode": "cors"}}
         )()
         self.assertTrue(_is_hx_request(request))
+
+
+class TestsRepoHelperTests(unittest.TestCase):
+    def test_tests_repo_returns_canonical_url_for_trailing_slash(self):
+        run = {
+            "args": {"tests_repo": "https://github.com/official-stockfish/Stockfish/"}
+        }
+
+        self.assertEqual(
+            tests_repo(run),
+            "https://github.com/official-stockfish/Stockfish",
+        )
+
+    def test_tests_repo_falls_back_for_empty_legacy_value(self):
+        run = {"args": {"tests_repo": ""}}
+
+        self.assertEqual(
+            tests_repo(run),
+            "https://github.com/official-stockfish/Stockfish",
+        )
 
 
 class PaginationTests(unittest.TestCase):

--- a/server/tests/test_views_run.py
+++ b/server/tests/test_views_run.py
@@ -207,6 +207,30 @@ class ValidateFormTests(unittest.TestCase):
         self.assertEqual(data["resolved_base"], BASE_SHA)
         self.assertEqual(data["resolved_new"], NEW_SHA)
 
+    def test_validate_form_canonicalizes_tests_repo_and_updates_user(self):
+        post_data = _valid_post_data()
+        post_data["tests-repo"] = BASE_REPO + "/"
+        request = _RequestStub(post_data=post_data)
+        request.userdb._user["tests_repo"] = BASE_REPO + "/"
+
+        with (
+            mock.patch("fishtest.views_run.gh.normalize_repo", return_value=BASE_REPO),
+            mock.patch(
+                "fishtest.views_run.gh.parse_repo",
+                return_value=("official-stockfish", "Stockfish"),
+            ),
+            mock.patch("fishtest.views_run.gh.get_master_repo", return_value=BASE_REPO),
+            mock.patch(
+                "fishtest.views_run.get_sha",
+                side_effect=[(BASE_SHA, "base"), (NEW_SHA, "new")],
+            ),
+            mock.patch("fishtest.views_run.get_nets", return_value=[]),
+        ):
+            data = validate_form(request)
+
+        self.assertEqual(data["tests_repo"], BASE_REPO)
+        self.assertEqual(request.userdb.saved_users[-1]["tests_repo"], BASE_REPO)
+
     def test_validate_form_rejects_invalid_arch_regex(self):
         post_data = _valid_post_data()
         post_data["checkbox-arch-filter"] = "on"


### PR DESCRIPTION
Strip a trailing slash from stored tests repository URLs while keeping user input permissive on signup, profile updates, and run creation.

Preserve renamed-repo normalization, store slash-free repo URLs in user and run documents, and keep worker GitHub download URLs stable when building zipball requests.
Add regression coverage for helper, user, form, and RunDb persistence paths.