### PR TITLE
perf(rundb): trim unfinished-run projection for run tables

### DIFF
--- a/docs/1-architecture.md
+++ b/docs/1-architecture.md
@@ -250,6 +250,12 @@ stable while htmx still applies the response's out-of-band section updates.
 The tasks table keeps its own conditional `/tests/tasks/{id}` poller because it
 has a separate shell/body + OOB-controls contract.
 
+Run-list and detail polling intentionally use different data shapes. The
+`/tests` and `/tests/user/{username}` run-table path rebuilds from
+`aggregate_unfinished_runs()` and the lightweight unfinished-run query, which
+omits `tasks`, `bad_tasks`, and `args.spsa.param_history`. Detail routes use
+full run data via `get_run()` and the dedicated tasks poller.
+
 **Visibility-aware polling policy.** Every periodic htmx poller follows a
 three-part trigger policy:
 

--- a/docs/5-templates.md
+++ b/docs/5-templates.md
@@ -551,6 +551,9 @@ Behavior notes:
 - `tests.html.j2` forwards the homepage Active-panel first-paint filter state
    through `run_tables_ctx`, including restored checkbox selections, filtered
    count text, and initial hide selectors.
+- `run_tables_ctx` is intentionally lightweight. Unfinished-run rows omit
+   `tasks`, `bad_tasks`, and `args.spsa.param_history`; task detail stays on
+   the detail and tasks routes.
 - Notification button state is not part of `run_tables_ctx` because it is
    derived from browser-local follow state at page load time.
 
@@ -935,6 +938,8 @@ submissions preserve the live table state.
 
 Behavior notes:
 
+- The unfinished-run portion of this fragment uses the same lightweight row
+  shape as `run_tables_ctx`.
 - When homepage workers filters are active, the fragment recomputes the
    `#workers-count` filtered value from the current machine snapshot instead of
    trusting the last cookie-backed filtered count.

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -63,7 +63,12 @@ from fishtest.util import (
 )
 from fishtest.workerdb import WorkerDb
 
-_UNFINISHED_RUNS_LIGHTWEIGHT_PROJECTION = {"_id": 1, "tasks": 0}
+_UNFINISHED_RUNS_LIGHTWEIGHT_PROJECTION = {
+    "_id": 1,
+    "tasks": 0,
+    "bad_tasks": 0,
+    "args.spsa.param_history": 0,
+}
 
 _UNFINISHED_RUNS_STATS_PROJECTION = {
     "_id": 1,

--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -152,6 +152,13 @@ class CreateRunDBTest(unittest.TestCase):
     def test_11_get_unfinished_runs_keeps_default_projection_lightweight(self):
         run_id = self._create_test_run()
         run = self.rundb.get_run(run_id)
+        run["args"]["spsa"] = {
+            "iter": 7,
+            "param_history": [[{"theta": 12.0, "c": 1.5}]],
+        }
+        run["bad_tasks"] = [
+            {"num_games": 0, "stats": {"wins": 0, "draws": 0, "losses": 0}}
+        ]
         run["tasks"][0]["worker_info"] = self.worker_info
         run["tasks"][0]["last_updated"] = datetime.now(UTC)
         run["tasks"][0]["stats"] = {
@@ -168,6 +175,9 @@ class CreateRunDBTest(unittest.TestCase):
         )
 
         self.assertNotIn("tasks", unfinished_run)
+        self.assertNotIn("bad_tasks", unfinished_run)
+        self.assertEqual(unfinished_run["args"]["spsa"]["iter"], 7)
+        self.assertNotIn("param_history", unfinished_run["args"]["spsa"])
 
     def test_12_get_unfinished_runs_for_stats_returns_task_projection(self):
         run_id = self._create_test_run()


### PR DESCRIPTION
Exclude bad_tasks and args.spsa.param_history from the default unfinished-run reader so run-table polling keeps the same lightweight contract while preserving the existing query shape and route behavior.

Keep the stats-specific unfinished-run reader unchanged, add regression coverage for SPSA subfield exclusion, and document the lightweight run-table context used by the templates.