### PR TITLE
fix(server): restore contributor games-per-hour rebuild in stats script

### DIFF
--- a/server/tests/test_delta_update_users.py
+++ b/server/tests/test_delta_update_users.py
@@ -1,8 +1,10 @@
 """Test monthly contributor stats rebuild helpers."""
 
 import copy
+import sys
 import unittest
 from datetime import UTC, datetime
+from unittest.mock import patch
 
 from utils import delta_update_users
 
@@ -40,7 +42,43 @@ class _FakeRunDb:
         return iter(self._unfinished_runs)
 
 
+class _FakeRunDbForRates:
+    def __init__(self, machines):
+        self._machines = machines
+
+    def get_machines(self):
+        return self._machines
+
+
 class DeltaUpdateUsersTest(unittest.TestCase):
+    def test_compute_games_rates_updates_both_info_dicts(self):
+        machine = {
+            "username": "worker-user",
+            "nps": delta_update_users.REFERENCE_CORE_NPS,
+            "concurrency": 2,
+            "run": {
+                "args": {
+                    "tc": "10+0.1",
+                    "threads": 1,
+                }
+            },
+        }
+        rundb = _FakeRunDbForRates([machine])
+        info_total = {"worker-user": _user_stats("worker-user")}
+        info_top_month = copy.deepcopy(info_total)
+
+        delta_update_users.compute_games_rates(rundb, info_total, info_top_month)
+
+        expected = 2 * (
+            3600
+            / delta_update_users.estimate_game_duration(machine["run"]["args"]["tc"])
+        )
+        self.assertAlmostEqual(info_total["worker-user"]["games_per_hour"], expected)
+        self.assertAlmostEqual(
+            info_top_month["worker-user"]["games_per_hour"],
+            expected,
+        )
+
     def test_process_run_requires_tasks(self):
         info = {"run-author": _user_stats("run-author")}
         run = {
@@ -88,6 +126,29 @@ class DeltaUpdateUsersTest(unittest.TestCase):
         self.assertEqual(info_top_month["worker-user"]["games"], 6)
         self.assertEqual(info_top_month["worker-user"]["last_updated"], last_updated)
         self.assertGreater(info_top_month["worker-user"]["cpu_hours"], 0.0)
+
+    def test_main_uses_db_backed_rundb_for_stats_rebuild(self):
+        fake_rundb = unittest.mock.Mock()
+        fake_rundb.deltas.find.return_value = []
+
+        with (
+            patch.object(
+                delta_update_users, "RunDb", return_value=fake_rundb
+            ) as run_db,
+            patch.object(delta_update_users, "initialize_info", return_value=({}, {})),
+            patch.object(delta_update_users, "update_info", return_value={}),
+            patch.object(delta_update_users, "compute_games_rates"),
+            patch.object(delta_update_users, "update_collection"),
+            patch.object(delta_update_users, "cleanup_users"),
+        ):
+            old_argv = sys.argv
+            try:
+                sys.argv = ["delta_update_users.py"]
+                delta_update_users.main()
+            finally:
+                sys.argv = old_argv
+
+        run_db.assert_called_once_with(is_primary_instance=False)
 
 
 if __name__ == "__main__":

--- a/server/utils/delta_update_users.py
+++ b/server/utils/delta_update_users.py
@@ -323,7 +323,10 @@ def main() -> None:
     Reads command-line arguments, processes run deltas, updates user statistics,
     and records the update operation.
     """
-    rundb = RunDb()
+    # This is a one-shot stats rebuild script, not a long-lived primary process.
+    # Use the DB-backed reader so get_machines() sees active workers instead of
+    # relying on the in-memory unfinished-run cache initialized by the web app.
+    rundb = RunDb(is_primary_instance=False)
     deltas = {}
     if len(sys.argv) == 1:
         # No guarantee that the returned natural order will be the insertion order


### PR DESCRIPTION
Construct the standalone delta_update_users rebuild with RunDb(is_primary_instance=False) so games_per_hour is derived from the DB-backed machines reader instead of the primary process's in-memory unfinished-run state.

This keeps the contributor rebuild correct in one-shot maintenance processes, where the primary-only active-run cache is empty and would otherwise collapse Games/Hour to zero for every user.

Add focused regression coverage for both the rate computation helper and the standalone RunDb construction path.