### PR TITLE
fix(ui): normalize UI cookie max-age to 10 years

### DIFF
--- a/docs/4-ui-reference.md
+++ b/docs/4-ui-reference.md
@@ -340,6 +340,9 @@ The UI uses two cookie families with different ownership and lifecycles:
    `FishtestSessionMiddleware`.
 - **UI state cookies** -- lightweight browser-side preferences such as `theme`,
    `contributors_findme`, `machines_state`, and the homepage workers filters.
+   These non-auth UI cookies use the shared `400 days` max-age policy from
+   `UI_STATE_COOKIE_MAX_AGE_SECONDS` and stay separate from the signed
+   session payload.
 
 ### Session cookie lifecycle
 
@@ -364,7 +367,8 @@ They are written by page-specific JS or server helpers because they do not
 carry authentication state:
 
 - `theme` is written by `static/js/application.js` and controls light/dark
-   presentation.
+   presentation. The same cookie is read during full-page renders so the server
+   can emit the matching theme before first paint.
 - `contributors_findme` is written by `static/js/contributors.js` and preserves
    rank-jump mode across contributors pages.
 - `machines_state` is written by `static/js/tests_homepage.js` and preserves
@@ -548,9 +552,9 @@ Behavior notes:
    only when the effective filter state is truly `All`.
 - The panel header count updates to show both total and filtered counts
   when a filter is active: "Active - N (M) tests".
-- Filter state is persisted in the `active_run_filters` cookie (30-day,
-  `path=/`, `SameSite=Lax`).  When all checkboxes are checked the cookie
-  is cleared.
+- Filter state is persisted in the `active_run_filters` cookie using the shared
+   long-lived UI-cookie policy (`path=/`, `SameSite=Lax`). When all checkboxes
+   are checked the cookie is cleared.
 - On page reload, `/tests` restores the cookie-backed filter state in the first
    HTML response, including the checkbox state, filtered count text, and initial
    row-hide CSS. Hidden categories therefore do not flash briefly before the

--- a/docs/5-templates.md
+++ b/docs/5-templates.md
@@ -215,10 +215,13 @@ Design rules:
    page-specific CSS minimum width.
 - **`autocomplete="off"`** on all search/filter text inputs to prevent
   browser autofill from interfering with htmx-driven filtering.
-- **Cookie max-age** must use `PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS` from
+- **Cookie max-age** must use `UI_STATE_COOKIE_MAX_AGE_SECONDS` from
   `settings.py`, never hardcoded values. Client-side cookies set via
   `hx-on::before-request` handlers use the Jinja variable
-  `{{ cookie_max_age }}` backed by this constant.
+   `{{ cookie_max_age }}` backed by this constant. This is the single max-age
+   owner for non-auth UI cookies; templates should expose
+   `cookies.ui_state_max_age` or a page-specific `cookie_max_age` context
+   instead of introducing alternate aliases or literals.
 
 Known gaps documented for future iterations:
 
@@ -921,7 +924,7 @@ Same context as `actions.html.j2` (`actions`, `visible_actions`, `num_actions`, 
 |-----|------|
 | `active_runs` | list (run dicts for the Active panel) |
 | `active_run_filters` | dict or `None` (parsed cookie state) |
-| `cookies.persistent_ui_max_age` | int (cookie max-age seconds) |
+| `cookies.ui_state_max_age` | int (cookie max-age seconds) |
 
 Renders the faceted filter panel (SPRT/SPSA/NumGames, STC/LTC, ST/SMP)
 above the Active runs table. Server-side rendering of initial checkbox

--- a/server/fishtest/http/boundary.py
+++ b/server/fishtest/http/boundary.py
@@ -29,7 +29,7 @@ from fishtest.http.dependencies import (
 )
 from fishtest.http.jinja import static_url
 from fishtest.http.open_graph import default_open_graph
-from fishtest.http.settings import SESSION_REMEMBER_MAX_AGE_SECONDS
+from fishtest.http.settings import SESSION_REMEMBER_ME_MAX_AGE_SECONDS
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -153,7 +153,7 @@ def commit_session_flags(
         max_age = (
             flags.remember_max_age
             if flags.remember_max_age is not None
-            else SESSION_REMEMBER_MAX_AGE_SECONDS
+            else SESSION_REMEMBER_ME_MAX_AGE_SECONDS
         )
         mark_session_max_age(request, max_age)
         request.scope["session_secure"] = is_https(request)

--- a/server/fishtest/http/jinja.py
+++ b/server/fishtest/http/jinja.py
@@ -24,8 +24,6 @@ from fishtest.http.settings import (
     FINISHED_FILTER_MAX_COUNT_ANON,
     FINISHED_FILTER_MAX_COUNT_AUTH,
     HTMX_INPUT_CHANGED_DELAY_MS,
-    PANEL_TOGGLE_COOKIE_MAX_AGE_SECONDS,
-    PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS,
     POLL_LIVE_ELO_S,
     POLL_MACHINES_HOMEPAGE_S,
     POLL_PENDING_USERS_NAV_S,
@@ -35,7 +33,7 @@ from fishtest.http.settings import (
     POLL_TESTS_RUN_TABLES_S,
     POLL_TESTS_STATS_S,
     POLL_TESTS_VIEW_DETAIL_S,
-    THEME_COOKIE_MAX_AGE_SECONDS,
+    UI_STATE_COOKIE_MAX_AGE_SECONDS,
 )
 from fishtest.util import get_tc_ratio as _get_tc_ratio
 
@@ -162,10 +160,8 @@ def default_environment() -> Environment:
             "filter_max_count_auth": FINISHED_FILTER_MAX_COUNT_AUTH,
         },
         "cookies": {
-            "contributors_findme_max_age": PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS,
-            "panel_toggle_max_age": PANEL_TOGGLE_COOKIE_MAX_AGE_SECONDS,
-            "persistent_ui_max_age": PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS,
-            "theme_max_age": THEME_COOKIE_MAX_AGE_SECONDS,
+            "contributors_findme_max_age": UI_STATE_COOKIE_MAX_AGE_SECONDS,
+            "ui_state_max_age": UI_STATE_COOKIE_MAX_AGE_SECONDS,
         },
     }
     env.globals.update(globals_map)

--- a/server/fishtest/http/session_middleware.py
+++ b/server/fishtest/http/session_middleware.py
@@ -21,7 +21,7 @@ from fishtest.http.cookie_session import (
     DEFAULT_SAMESITE,
     SESSION_COOKIE_NAME,
 )
-from fishtest.http.settings import SESSION_MAX_COOKIE_BYTES
+from fishtest.http.settings import SESSION_COOKIE_VALUE_MAX_BYTES
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -226,7 +226,7 @@ def _delete_cookie_header(
 
 
 def _cookie_size_ok(value: str) -> bool:
-    return len(value.encode("utf-8")) <= SESSION_MAX_COOKIE_BYTES
+    return len(value.encode("utf-8")) <= SESSION_COOKIE_VALUE_MAX_BYTES
 
 
 def _encode_cookie_value(

--- a/server/fishtest/http/settings.py
+++ b/server/fishtest/http/settings.py
@@ -36,11 +36,11 @@ POLL_PENDING_USERS_NAV_S: int = 10
 HTMX_INPUT_CHANGED_DELAY_MS: int = 350
 
 # Shared cookie and session policy for the UI and HTTP boundary.
-SESSION_MAX_COOKIE_BYTES: int = 3800
-PANEL_TOGGLE_COOKIE_MAX_AGE_SECONDS: int = 60 * 60
-THEME_COOKIE_MAX_AGE_SECONDS: int = 60 * 60 * 24 * 30
-PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS: int = 60 * 60 * 24 * 30
-SESSION_REMEMBER_MAX_AGE_SECONDS: int = 60 * 60 * 24 * 365
+# Keep session cookie values below the practical 4 KB browser limit, leaving
+# room for the cookie name and attributes.
+SESSION_COOKIE_VALUE_MAX_BYTES: int = 3800
+SESSION_REMEMBER_ME_MAX_AGE_SECONDS: int = 60 * 60 * 24 * 400
+UI_STATE_COOKIE_MAX_AGE_SECONDS: int = 60 * 60 * 24 * 400
 
 # Template and UI view defaults.
 WORKERS_PAGE_SIZE: int = 25

--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -179,9 +179,7 @@ function setTheme(theme) {
     document.documentElement.style.colorScheme = "";
     darkLink?.remove();
   }
-  document.cookie = `theme=${theme}; path=/; max-age=${
-    10 * 365 * 24 * 60 * 60
-  }; SameSite=Lax`;
+  setStateCookie("theme", theme, window.uiStateCookieMaxAgeSeconds);
 }
 
 function supportsNotifications() {

--- a/server/fishtest/templates/active_run_filters_fragment.html.j2
+++ b/server/fishtest/templates/active_run_filters_fragment.html.j2
@@ -1,8 +1,6 @@
 {% set active_run_filters = active_run_filters if active_run_filters is defined and active_run_filters else none %}
 {% set enabled = active_run_filters.enabled_by_dim if active_run_filters else {} %}
-<div id="active-run-filters"
-     class="mb-2"
-     data-filter-cookie-max-age="{{ cookies.persistent_ui_max_age }}">
+<div id="active-run-filters" class="mb-2" data-filter-cookie-max-age="{{ cookies.ui_state_max_age }}">
   <button type="button"
           id="active-filter-toggle"
           class="active-filter-toggle"

--- a/server/fishtest/templates/base.html.j2
+++ b/server/fishtest/templates/base.html.j2
@@ -30,6 +30,7 @@
 
     <script>
       const darkThemeHash = {{ static_url('fishtest:static/css/theme.dark.css') | tojson }};
+      window.uiStateCookieMaxAgeSeconds = {{ cookies.ui_state_max_age | tojson }};
       try {
         document.documentElement.dataset.githubRateLimitLow =
           localStorage.getItem("fishtest_github_rate_limit_low") === "1"

--- a/server/fishtest/templates/run_table.html.j2
+++ b/server/fishtest/templates/run_table.html.j2
@@ -15,13 +15,18 @@
 
 <h4>
 {% if toggle %}
-  <a id="{{ toggle }}-button" class="btn btn-sm btn-light border"
-  data-bs-toggle="collapse" href="#{{ toggle }}" role="button"
-  aria-expanded="{{ 'true' if toggle_state == 'Hide' else 'false' }}"
-      aria-controls="{{ toggle }}"
-      data-toggle-cookie-name="{{ cookie_name }}"
-      data-toggle-cookie-max-age="{{ 60 * 60 * 24 * 365 * 10 }}">
-  {{ 'Hide' if toggle_state == 'Hide' else 'Show' }}
+  <a
+    id="{{ toggle }}-button"
+    class="btn btn-sm btn-light border"
+    data-bs-toggle="collapse"
+    href="#{{ toggle }}"
+    role="button"
+    aria-expanded="{{ 'true' if toggle_state == 'Hide' else 'false' }}"
+    aria-controls="{{ toggle }}"
+    data-toggle-cookie-name="{{ cookie_name }}"
+    data-toggle-cookie-max-age="{{ cookies.ui_state_max_age }}"
+  >
+    {{ 'Hide' if toggle_state == 'Hide' else 'Show' }}
   </a>
 {% endif %}
 {% if header is not none and count is not none %}

--- a/server/fishtest/templates/tests.html.j2
+++ b/server/fishtest/templates/tests.html.j2
@@ -30,7 +30,7 @@
     <a
       id="machines-button"
       class="btn btn-sm btn-light border"
-      data-toggle-cookie-max-age="{{ cookies.panel_toggle_max_age }}"
+      data-toggle-cookie-max-age="{{ cookies.ui_state_max_age }}"
       data-bs-toggle="collapse"
       href="#machines-panel"
       role="button"

--- a/server/fishtest/templates/tests_live_elo.html.j2
+++ b/server/fishtest/templates/tests_live_elo.html.j2
@@ -25,7 +25,8 @@
       title="Click to switch Elo gauge scale mode"
       aria-label="Switch Elo gauge scale mode"
       data-elo-mode-default="fixed"
-      data-elo-mode-cookie-max-age="{{ cookies.persistent_ui_max_age }}"></div>
+      data-elo-mode-cookie-max-age="{{ cookies.ui_state_max_age }}"
+    ></div>
   </div>
   <h4>Details</h4>
   <div class="col-12 table-responsive-lg">

--- a/server/fishtest/templates/tests_view.html.j2
+++ b/server/fishtest/templates/tests_view.html.j2
@@ -304,17 +304,24 @@
   {% endif %}
 
   <h4>
-      <a
-        id="tasks-button" class="btn btn-sm btn-light border"
-        data-bs-toggle="collapse" href="#tasks" role="button" aria-expanded="false"
-        aria-controls="tasks"
-      >
-        {{ "Hide" if tasks_shown else "Show" }}
-      </a>
+    <a
+      id="tasks-button"
+      class="btn btn-sm btn-light border"
+      data-toggle-cookie-max-age="{{ cookies.ui_state_max_age }}"
+      data-bs-toggle="collapse"
+      href="#tasks"
+      role="button"
+      aria-expanded="false"
+      aria-controls="tasks"
+    >
+      {{ "Hide" if tasks_shown else "Show" }}
+    </a>
     Tasks <span id="tasks-totals">{{ tasks_totals }}</span>
   </h4>
-  <section id="tasks"
-       class="collapse {{ "show" if tasks_shown else "" }}">
+  <section
+    id="tasks"
+    class="collapse {{ "show" if tasks_shown else "" }}"
+  >
     <form
       id="tasks-filters"
       class="row g-2 align-items-end mb-2"
@@ -543,9 +550,11 @@
     btn?.addEventListener("click", () => {
       const active = btn.textContent.trim() === "Hide";
       btn.textContent = active ? "Show" : "Hide";
-      document.cookie =
-        "tasks_state=" + btn.textContent.trim() +
-        "; path=/; max-age={{ 60 * 60 }}; SameSite=Lax";
+      setStateCookie(
+        "tasks_state",
+        btn.textContent.trim(),
+        btn.dataset.toggleCookieMaxAge,
+      );
       if (!active && tasksContainer && tasksContainer.dataset.tasksLoaded !== "1") {
         tasksContainer.dataset.tasksLoaded = "loading";
         htmx.trigger(tasksContainer, "tasks:load");

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -59,14 +59,14 @@ from fishtest.http.settings import (
     CONTRIBUTORS_PAGE_SIZE,
     NNS_MAX_ALL,
     NNS_PAGE_SIZE,
-    PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS,
-    SESSION_REMEMBER_MAX_AGE_SECONDS,
+    SESSION_REMEMBER_ME_MAX_AGE_SECONDS,
     TASKS_MAX_ALL,
     TASKS_PAGE_SIZE,
     UI_FORM_MAX_FIELDS,
     UI_FORM_MAX_FILES,
     UI_FORM_MAX_PART_SIZE_BYTES,
     UI_HTTP_TIMEOUT_SECONDS,
+    UI_STATE_COOKIE_MAX_AGE_SECONDS,
     USER_MANAGEMENT_MAX_ALL,
     USER_MANAGEMENT_PAGE_SIZE,
     WORKERS_MAX_ALL,
@@ -602,8 +602,7 @@ def login(request: _ViewContext) -> dict[str, Any] | RedirectResponse:
         token = request.userdb.authenticate(username, password)
         if "error" not in token:
             if stay_logged_in:
-                # Session persists for a year after login
-                remember(request, username, max_age=SESSION_REMEMBER_MAX_AGE_SECONDS)
+                remember(request, username, max_age=SESSION_REMEMBER_ME_MAX_AGE_SECONDS)
             else:
                 # Session ends when the browser is closed
                 remember(request, username)
@@ -1361,7 +1360,7 @@ def nns(request: _ViewContext) -> dict[str, Any] | Response:  # noqa: C901, PLR0
         },
         "network_name_filter": network_name,
         "user_filter": user,
-        "cookie_max_age": PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS,
+        "cookie_max_age": UI_STATE_COOKIE_MAX_AGE_SECONDS,
     }
 
     return (
@@ -3098,7 +3097,7 @@ def _set_tasks_cookies(
     request: _ViewContext,
     state: dict[str, Any],
 ) -> None:
-    cookie_max_age = PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS
+    cookie_max_age = UI_STATE_COOKIE_MAX_AGE_SECONDS
     _set_tasks_cookie(request, "tasks_sort", str(state["sort"]), cookie_max_age)
     _set_tasks_cookie(request, "tasks_order", str(state["order"]), cookie_max_age)
     _set_tasks_cookie(request, "tasks_view", str(state["view"]), cookie_max_age)

--- a/server/fishtest/views_machines.py
+++ b/server/fishtest/views_machines.py
@@ -1,6 +1,6 @@
 """Build the `/tests/machines` filtering and pagination contract.
 
-Normalize rows, apply filtering and sorting, manage persistent UI cookies, and
+Normalize rows, apply filtering and sorting, manage UI-state cookies, and
 support the ``tests_machines`` entry point.
 """
 
@@ -12,7 +12,7 @@ from urllib.parse import quote, unquote
 
 from fishtest.http.settings import (
     MACHINES_PAGE_SIZE,
-    PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS,
+    UI_STATE_COOKIE_MAX_AGE_SECONDS,
 )
 from fishtest.util import format_time_ago, worker_name
 from fishtest.views_helpers import (
@@ -261,7 +261,7 @@ def _set_machine_cookies(  # noqa: PLR0913
     my_workers: bool,
     filtered_count: int,
 ) -> None:
-    cookie_max_age = PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS
+    cookie_max_age = UI_STATE_COOKIE_MAX_AGE_SECONDS
     _set_machine_cookie(request, "machines_sort", sort_param, cookie_max_age)
     _set_machine_cookie(request, "machines_order", order_param, cookie_max_age)
     _set_machine_cookie(request, "machines_page", str(page), cookie_max_age)

--- a/server/tests/test_http_helpers.py
+++ b/server/tests/test_http_helpers.py
@@ -136,7 +136,7 @@ class CookieSessionTests(unittest.TestCase):
 
             from fishtest.http.cookie_session import load_session
             from fishtest.http.session_middleware import FishtestSessionMiddleware
-            from fishtest.http.settings import SESSION_MAX_COOKIE_BYTES
+            from fishtest.http.settings import SESSION_COOKIE_VALUE_MAX_BYTES
 
             app.add_middleware(
                 FishtestSessionMiddleware,
@@ -167,7 +167,7 @@ class CookieSessionTests(unittest.TestCase):
             )[0]
             self.assertLessEqual(
                 len(cookie_value.encode("utf-8")),
-                SESSION_MAX_COOKIE_BYTES,
+                SESSION_COOKIE_VALUE_MAX_BYTES,
             )
 
 

--- a/server/tests/test_http_settings.py
+++ b/server/tests/test_http_settings.py
@@ -6,9 +6,9 @@ from unittest import mock
 
 from fishtest.http.settings import (
     HTMX_INPUT_CHANGED_DELAY_MS,
-    PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS,
     TASK_SEMAPHORE_SIZE,
     THREADPOOL_TOKENS,
+    UI_STATE_COOKIE_MAX_AGE_SECONDS,
     AppSettings,
     default_static_dir,
     env_int,
@@ -73,4 +73,7 @@ class SettingsContractTests(unittest.TestCase):
     def test_runtime_limits_keep_headroom_for_http_work(self):
         self.assertGreater(THREADPOOL_TOKENS, TASK_SEMAPHORE_SIZE)
         self.assertGreater(HTMX_INPUT_CHANGED_DELAY_MS, 0)
-        self.assertGreater(PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS, 0)
+        self.assertEqual(
+            UI_STATE_COOKIE_MAX_AGE_SECONDS,
+            60 * 60 * 24 * 400,
+        )

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -8,7 +8,7 @@ import test_support
 from ui_user_test_case import UiUserTestCase
 from vtjson import ValidationError
 
-from fishtest.http.settings import SESSION_REMEMBER_MAX_AGE_SECONDS
+from fishtest.http.settings import SESSION_REMEMBER_ME_MAX_AGE_SECONDS
 from fishtest.util import PASSWORD_MAX_LENGTH
 
 
@@ -242,7 +242,7 @@ class TestUsers(UiUserTestCase):
         self._assert_no_store_headers(response)
         cookie = response.headers.get("set-cookie", "")
         self.assertIn("fishtest_session=", cookie)
-        self.assertIn(f"Max-Age={SESSION_REMEMBER_MAX_AGE_SECONDS}", cookie)
+        self.assertIn(f"Max-Age={SESSION_REMEMBER_ME_MAX_AGE_SECONDS}", cookie)
 
     def test_login_duplicate_remember_fields_keep_persistent_cookie(self):
         response = self.client.get("/login")
@@ -266,7 +266,7 @@ class TestUsers(UiUserTestCase):
         self.assertEqual(response.status_code, 302)
         cookie = response.headers.get("set-cookie", "")
         self.assertIn("fishtest_session=", cookie)
-        self.assertIn(f"Max-Age={SESSION_REMEMBER_MAX_AGE_SECONDS}", cookie)
+        self.assertIn(f"Max-Age={SESSION_REMEMBER_ME_MAX_AGE_SECONDS}", cookie)
 
     def test_login_explicit_non_remember_sets_session_cookie(self):
         response = self.client.get("/login")

--- a/server/tests/test_views_detail.py
+++ b/server/tests/test_views_detail.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import test_support
 from ui_user_test_case import UiUserTestCase
 
+from fishtest.http.settings import UI_STATE_COOKIE_MAX_AGE_SECONDS
 from fishtest.run_cache import Prio
 
 
@@ -201,6 +202,22 @@ class TestTestsViewDetail(unittest.TestCase):
         self.assertIn("Total:", description)
         self.assertIn("\n", description)
         self.assertNotIn("```", description)
+
+    def test_tests_view_page_uses_shared_ui_cookie_max_age_for_theme_and_tasks(self):
+        run_id = self._create_run()
+
+        response = self.client.get(f"/tests/view/{run_id}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            f"window.uiStateCookieMaxAgeSeconds = {UI_STATE_COOKIE_MAX_AGE_SECONDS};",
+            response.text,
+        )
+        self.assertIn('id="tasks-button"', response.text)
+        self.assertIn(
+            f'data-toggle-cookie-max-age="{UI_STATE_COOKIE_MAX_AGE_SECONDS}"',
+            response.text,
+        )
 
     def test_tests_view_page_open_graph_description_is_multiline_and_keeps_ptnml(
         self,

--- a/server/tests/test_views_machines.py
+++ b/server/tests/test_views_machines.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from ui_user_test_case import UiUserTestCase
 
-from fishtest.http.settings import PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS
+from fishtest.http.settings import UI_STATE_COOKIE_MAX_AGE_SECONDS
 from fishtest.views_machines import (
     _MACHINES_PAGE_SIZE,
     _filtered_machine_count,
@@ -179,7 +179,7 @@ class TestsMachinesEntryPointTests(unittest.TestCase):
         self.assertEqual(len(cookie_headers), EXPECTED_MACHINE_COOKIE_COUNT)
         for cookie_header in cookie_headers:
             self.assertIn(
-                f"max-age={PERSISTENT_UI_COOKIE_MAX_AGE_SECONDS}",
+                f"max-age={UI_STATE_COOKIE_MAX_AGE_SECONDS}",
                 cookie_header,
             )
 

--- a/server/tests/test_views_tests.py
+++ b/server/tests/test_views_tests.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 from ui_user_test_case import UiUserTestCase
 
+from fishtest.http.settings import UI_STATE_COOKIE_MAX_AGE_SECONDS
+
 
 class TestTestsHomepage(UiUserTestCase):
     username = "TestHomepageUser"
@@ -253,7 +255,10 @@ class TestTestsHomepage(UiUserTestCase):
         self.assertIn('id="machines_order" name="order" value="asc"', homepage.text)
         self.assertIn('id="machines_page" name="page" value="1"', homepage.text)
         self.assertIn("checked", homepage.text)
-        self.assertIn('data-toggle-cookie-max-age="', homepage.text)
+        self.assertIn(
+            f'data-toggle-cookie-max-age="{UI_STATE_COOKIE_MAX_AGE_SECONDS}"',
+            homepage.text,
+        )
         self.assertIn("static/js/tests_homepage.js", homepage.text)
         self.assertNotIn("document.activeElement?.id !== 'machines_q'", homepage.text)
         self.assertIn(
@@ -645,7 +650,10 @@ class TestTestsHomepage(UiUserTestCase):
         self.assertIn('id="tests-user-filters"', response.text)
         self.assertIn('id="notification_', response.text)
         self.assertIn('data-toggle-cookie-name="', response.text)
-        self.assertIn('data-toggle-cookie-max-age="', response.text)
+        self.assertIn(
+            f'data-toggle-cookie-max-age="{UI_STATE_COOKIE_MAX_AGE_SECONDS}"',
+            response.text,
+        )
 
     def test_notifications_js_reinitializes_after_htmx_swaps(self):
         js_path = (


### PR DESCRIPTION
Keep the current cookie-based state model and remove max-age ownership bugs.

- keep all current cookie families
- normalize non-auth UI cookie lifetimes to 10 years
- remove hard-coded template and JS max-age definitions
- make one shared source own UI cookie max-age
- update docs to match the cookie contract actually in use