### PR TITLE
fix(auth): persist login remember-me preference

### DIFF
--- a/docs/4-ui-reference.md
+++ b/docs/4-ui-reference.md
@@ -370,6 +370,10 @@ carry authentication state:
 - `theme` is written by `static/js/application.js` and controls light/dark
    presentation. The same cookie is read during full-page renders so the server
    can emit the matching theme before first paint.
+- `login_remember_me` is written by `POST /login` and mirrored by
+   `static/js/application.js` when the checkbox changes. It keeps the login
+   form's explicit opt-out state across browser restarts without changing the
+   signed auth-cookie lifetime.
 - `contributors_findme` is written by `static/js/contributors.js` and preserves
    rank-jump mode across contributors pages.
 - `machines_state` is written by `static/js/tests_homepage.js` and preserves
@@ -402,11 +406,18 @@ while letting low-risk UI preferences remain simple, readable browser state.
 
 ### Login flow
 
-1. User submits username/password to `POST /login`.
-2. `UserDb.authenticate()` validates credentials.
-3. On success, `remember(request, username)` sets `session["user"]`.
-4. Optional "stay logged in" sets `session_max_age` to 1 year.
-5. Redirect to the `next` URL or the referrer.
+1. `GET /login` renders the Remember me checkbox checked by default.
+2. If the `login_remember_me` UI cookie stores an explicit opt-out, the same
+   page renders the checkbox unchecked on later visits.
+3. User submits username/password to `POST /login`.
+4. `UserDb.authenticate()` validates credentials.
+5. On success, `remember(request, username)` sets `session["user"]`.
+6. Checked Remember me emits a persistent signed session cookie using the
+   shared remember-me lifetime. Unchecked login keeps the auth cookie scoped to
+   the current browser session.
+7. `POST /login` also refreshes `login_remember_me` so the user's explicit
+   checkbox choice survives later browser starts.
+8. Redirect to the `next` URL or the referrer.
 
 ### Logout flow
 

--- a/docs/5-templates.md
+++ b/docs/5-templates.md
@@ -389,7 +389,23 @@ The `elo` dict contains: `info_lines`, `pre_attrs`, `show_gauge`, `chart_div_id`
 
 ### `login.html.j2`
 
-Shared base context only.
+| Key | Type | Description |
+|-----|------|-------------|
+| `remember_me_checked` | bool | Initial checked state for the Remember me checkbox |
+| `remember_me_cookie_name` | string | UI-state cookie name mirrored by shared application JS |
+
+Behavior notes:
+
+- The form submits `stay_logged_in=0` through a hidden input and
+   `stay_logged_in=1` through the checkbox so the server can distinguish an
+   explicit opt-out from the checked/default case.
+- When no `login_remember_me` UI cookie exists, the checkbox renders checked.
+   An explicit opt-out stored in that cookie renders the checkbox unchecked on
+   later visits.
+- `login.html.j2` defaults `remember_me_cookie_name` to `login_remember_me`
+   because the same template is also used for generic UI 403 rendering.
+- `application.js` mirrors checkbox changes into the same UI-state cookie, and
+   `POST /login` refreshes it server-side for progressive enhancement.
 
 ### `machines_fragment.html.j2`
 

--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -13,6 +13,7 @@ let broadcastDispatch = {
   handlePanelToggleCookies();
   handleApplicationLogout();
   handleApplicationThemes();
+  handleLoginRememberMePreference();
   handleClientRateLimitPolling();
 })();
 
@@ -114,6 +115,21 @@ function handlePanelToggleCookies() {
 
     button.textContent = nextState;
     setStateCookie(cookieName, nextState, maxAge);
+  });
+}
+
+function handleLoginRememberMePreference() {
+  const checkbox = document.querySelector("[data-remember-me-cookie-name]");
+  if (!(checkbox instanceof HTMLInputElement) || checkbox.type !== "checkbox") {
+    return;
+  }
+
+  const cookieName = checkbox.dataset.rememberMeCookieName;
+  const maxAge =
+    checkbox.dataset.rememberMeCookieMaxAge ||
+    window.uiStateCookieMaxAgeSeconds;
+  checkbox.addEventListener("change", () => {
+    setStateCookie(cookieName, checkbox.checked ? "1" : "0", maxAge);
   });
 }
 

--- a/server/fishtest/templates/login.html.j2
+++ b/server/fishtest/templates/login.html.j2
@@ -4,6 +4,8 @@
 
 {% block body %}
 {% set signup_url = urls.signup %}
+{% set remember_me_checked = remember_me_checked | default(true) %}
+{% set remember_me_cookie_name = remember_me_cookie_name | default('login_remember_me') %}
 
 <div class="col-limited-size">
   <header class="text-md-center py-2">
@@ -57,7 +59,9 @@
         id="staylogged"
         name="stay_logged_in"
         value="1"
-        checked
+        data-remember-me-cookie-name="{{ remember_me_cookie_name }}"
+        data-remember-me-cookie-max-age="{{ cookies.ui_state_max_age }}"
+        {% if remember_me_checked %}checked{% endif %}
       >
     </div>
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -166,6 +166,9 @@ _MAX_NETWORK_SIZE_BYTES = 200_000_000
 _THROUGHPUT_NORMAL_LIMIT = 100
 _MIN_BOOK_EXITS = 100_000
 _RUN_AGE_GITHUB_API_MAX_DAYS = 30
+_LOGIN_REMEMBER_ME_COOKIE_NAME = "login_remember_me"
+_LOGIN_REMEMBER_ME_TRUE_VALUES = frozenset({"1", "true", "on", "yes"})
+_LOGIN_REMEMBER_ME_FALSE_VALUES = frozenset({"0", "false", "off", "no"})
 
 _ACTIVE_RUN_FILTER_VALUES = {
     "test-type": ("sprt", "spsa", "numgames"),
@@ -568,6 +571,64 @@ def ensure_logged_in(request: _ViewContext) -> str | RedirectResponse:
     return userid
 
 
+def _set_ui_state_cookie(
+    request: _ViewContext,
+    name: str,
+    value: str,
+    max_age_seconds: int,
+) -> None:
+    cookie_value = (
+        f"{name}={quote(value, safe='')}; path=/; max-age={max_age_seconds}; "
+        "SameSite=Lax"
+    )
+    # Keep duplicate Set-Cookie headers intact so UI-state cookies can coexist
+    # with the signed session cookie on the same response.
+    request.response_headerlist.append(("Set-Cookie", cookie_value))
+
+
+def _login_remember_me_checked(request: _ViewContext) -> bool:
+    raw_value = str(request.cookies.get(_LOGIN_REMEMBER_ME_COOKIE_NAME, ""))
+    cookie_value = raw_value.strip().lower()
+    if cookie_value in _LOGIN_REMEMBER_ME_FALSE_VALUES:
+        return False
+    if cookie_value in _LOGIN_REMEMBER_ME_TRUE_VALUES:
+        return True
+    return True
+
+
+def _login_remember_me_checked_from_form(post_data: Any) -> bool:
+    submitted_values: list[str] = []
+    getlist = getattr(post_data, "getlist", None)
+    if callable(getlist):
+        submitted_values = [
+            str(value).strip().lower() for value in getlist("stay_logged_in")
+        ]
+    else:
+        raw_value = post_data.get("stay_logged_in")
+        if raw_value is not None:
+            submitted_values = [str(raw_value).strip().lower()]
+
+    # Default to the checked state when old clients or tests omit the field,
+    # and treat any explicit truthy value as the checked path when both the
+    # hidden fallback and checkbox values are submitted.
+    return not submitted_values or any(
+        value in _LOGIN_REMEMBER_ME_TRUE_VALUES for value in submitted_values
+    )
+
+
+def _set_login_remember_me_cookie(
+    request: _ViewContext,
+    *,
+    remember_me_checked: bool,
+) -> None:
+    _set_ui_state_cookie(
+        request,
+        _LOGIN_REMEMBER_ME_COOKIE_NAME,
+        "1" if remember_me_checked else "0",
+        UI_STATE_COOKIE_MAX_AGE_SECONDS,
+    )
+
+
 def login(request: _ViewContext) -> dict[str, Any] | RedirectResponse:
     _append_no_store_headers(request)
     userid = request.authenticated_userid
@@ -578,30 +639,20 @@ def login(request: _ViewContext) -> dict[str, Any] | RedirectResponse:
     if referrer == login_url:
         referrer = "/"  # never use the login form itself as came_from
     came_from = request.params.get("came_from", referrer)
+    remember_me_checked = _login_remember_me_checked(request)
 
     if request.method == "POST":
-        stay_logged_in_values: list[str] = []
-        getlist = getattr(request.POST, "getlist", None)
-        if callable(getlist):
-            stay_logged_in_values = [
-                str(v).strip().lower() for v in getlist("stay_logged_in")
-            ]
-        else:
-            raw_stay_logged_in = request.POST.get("stay_logged_in")
-            if raw_stay_logged_in is not None:
-                stay_logged_in_values = [str(raw_stay_logged_in).strip().lower()]
-
-        # Default to persistent login when the field is absent, and allow
-        # explicit opt-out via stay_logged_in=0.
-        stay_logged_in = not stay_logged_in_values or any(
-            value in {"1", "true", "on", "yes"} for value in stay_logged_in_values
+        remember_me_checked = _login_remember_me_checked_from_form(request.POST)
+        _set_login_remember_me_cookie(
+            request,
+            remember_me_checked=remember_me_checked,
         )
 
         username = _form_string_value(request.POST, "username")
         password = _form_string_value(request.POST, "password")
         token = request.userdb.authenticate(username, password)
         if "error" not in token:
-            if stay_logged_in:
+            if remember_me_checked:
                 remember(request, username, max_age=SESSION_REMEMBER_ME_MAX_AGE_SECONDS)
             else:
                 # Session ends when the browser is closed
@@ -618,7 +669,10 @@ def login(request: _ViewContext) -> dict[str, Any] | RedirectResponse:
                 "Thank you!"
             )
         request.session.flash(message, "error")
-    return {}
+    return {
+        "remember_me_checked": remember_me_checked,
+        "remember_me_cookie_name": _LOGIN_REMEMBER_ME_COOKIE_NAME,
+    }
 
 
 def logout(request: _ViewContext) -> RedirectResponse:
@@ -3081,16 +3135,7 @@ def _set_tasks_cookie(
     value: str,
     max_age_seconds: int,
 ) -> None:
-    cookie_value = (
-        f"{name}={quote(value, safe='')}; path=/; max-age={max_age_seconds}; "
-        "SameSite=Lax"
-    )
-    request.response_headerlist.append(
-        (
-            "Set-Cookie",
-            cookie_value,
-        ),
-    )
+    _set_ui_state_cookie(request, name, value, max_age_seconds)
 
 
 def _set_tasks_cookies(

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -8,7 +8,10 @@ import test_support
 from ui_user_test_case import UiUserTestCase
 from vtjson import ValidationError
 
-from fishtest.http.settings import SESSION_REMEMBER_ME_MAX_AGE_SECONDS
+from fishtest.http.settings import (
+    SESSION_REMEMBER_ME_MAX_AGE_SECONDS,
+    UI_STATE_COOKIE_MAX_AGE_SECONDS,
+)
 from fishtest.util import PASSWORD_MAX_LENGTH
 
 
@@ -18,6 +21,12 @@ class TestUsers(UiUserTestCase):
     def _assert_no_store_headers(self, response):
         self.assertEqual(response.headers.get("Cache-Control"), "no-store")
         self.assertEqual(response.headers.get("Expires"), "0")
+
+    def _response_cookie(self, response, name):
+        for cookie in response.headers.get_list("set-cookie"):
+            if cookie.startswith(f"{name}="):
+                return cookie
+        return ""
 
     def _check_auth_with_flag(self, field, expected_error, expected_code):
         user = self.rundb.userdb.get_user(self.username)
@@ -221,7 +230,29 @@ class TestUsers(UiUserTestCase):
         self.assertIn('name="stay_logged_in" value="0"', response.text)
         self.assertIn('name="stay_logged_in"', response.text)
         self.assertIn('id="staylogged"', response.text)
-        self.assertIn("checked", response.text)
+        self.assertIn(
+            'data-remember-me-cookie-name="login_remember_me"',
+            response.text,
+        )
+        self.assertIn(
+            f'data-remember-me-cookie-max-age="{UI_STATE_COOKIE_MAX_AGE_SECONDS}"',
+            response.text,
+        )
+        self.assertRegex(
+            response.text,
+            r'(?s)<input[^>]*id="staylogged"[^>]*checked[^>]*>',
+        )
+
+    def test_login_page_remember_me_cookie_can_uncheck_box(self):
+        response = self.client.get(
+            "/login",
+            headers={"cookie": "login_remember_me=0"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotRegex(
+            response.text,
+            r'(?s)<input[^>]*id="staylogged"[^>]*checked[^>]*>',
+        )
 
     def test_login_default_sets_persistent_cookie(self):
         response = self.client.get("/login")
@@ -240,9 +271,15 @@ class TestUsers(UiUserTestCase):
         )
         self.assertEqual(response.status_code, 302)
         self._assert_no_store_headers(response)
-        cookie = response.headers.get("set-cookie", "")
-        self.assertIn("fishtest_session=", cookie)
-        self.assertIn(f"Max-Age={SESSION_REMEMBER_ME_MAX_AGE_SECONDS}", cookie)
+        session_cookie = self._response_cookie(response, "fishtest_session")
+        remember_cookie = self._response_cookie(response, "login_remember_me")
+        self.assertIn("fishtest_session=", session_cookie)
+        self.assertIn(
+            f"Max-Age={SESSION_REMEMBER_ME_MAX_AGE_SECONDS}",
+            session_cookie,
+        )
+        self.assertIn("login_remember_me=1", remember_cookie)
+        self.assertIn(f"max-age={UI_STATE_COOKIE_MAX_AGE_SECONDS}", remember_cookie)
 
     def test_login_duplicate_remember_fields_keep_persistent_cookie(self):
         response = self.client.get("/login")
@@ -264,9 +301,15 @@ class TestUsers(UiUserTestCase):
             follow_redirects=False,
         )
         self.assertEqual(response.status_code, 302)
-        cookie = response.headers.get("set-cookie", "")
-        self.assertIn("fishtest_session=", cookie)
-        self.assertIn(f"Max-Age={SESSION_REMEMBER_ME_MAX_AGE_SECONDS}", cookie)
+        session_cookie = self._response_cookie(response, "fishtest_session")
+        remember_cookie = self._response_cookie(response, "login_remember_me")
+        self.assertIn("fishtest_session=", session_cookie)
+        self.assertIn(
+            f"Max-Age={SESSION_REMEMBER_ME_MAX_AGE_SECONDS}",
+            session_cookie,
+        )
+        self.assertIn("login_remember_me=1", remember_cookie)
+        self.assertIn(f"max-age={UI_STATE_COOKIE_MAX_AGE_SECONDS}", remember_cookie)
 
     def test_login_explicit_non_remember_sets_session_cookie(self):
         response = self.client.get("/login")
@@ -284,9 +327,33 @@ class TestUsers(UiUserTestCase):
             follow_redirects=False,
         )
         self.assertEqual(response.status_code, 302)
-        cookie = response.headers.get("set-cookie", "")
-        self.assertIn("fishtest_session=", cookie)
-        self.assertNotIn("Max-Age=", cookie)
+        session_cookie = self._response_cookie(response, "fishtest_session")
+        remember_cookie = self._response_cookie(response, "login_remember_me")
+        self.assertIn("fishtest_session=", session_cookie)
+        self.assertNotIn("Max-Age=", session_cookie)
+        self.assertIn("login_remember_me=0", remember_cookie)
+        self.assertIn(f"max-age={UI_STATE_COOKIE_MAX_AGE_SECONDS}", remember_cookie)
+
+    def test_login_invalid_password_keeps_explicit_non_remember_preference(self):
+        response = self.client.get("/login")
+        self.assertEqual(response.status_code, 200)
+        csrf = test_support.extract_csrf_token(response.text)
+
+        response = self.client.post(
+            "/login",
+            data={
+                "username": self.username,
+                "password": "wrong-test-password",
+                "stay_logged_in": "0",
+                "csrf_token": csrf,
+            },
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Invalid username or password.", response.text)
+        remember_cookie = self._response_cookie(response, "login_remember_me")
+        self.assertIn("login_remember_me=0", remember_cookie)
+        self.assertIn(f"max-age={UI_STATE_COOKIE_MAX_AGE_SECONDS}", remember_cookie)
 
     def test_signup_page_has_csrf_meta(self):
         response = self.client.get("/signup")


### PR DESCRIPTION
Keep the login Remember me checkbox checked by default and preserve the user's last explicit choice across browser restarts.

Read a dedicated login_remember_me UI-state cookie on GET /login, refresh it on POST /login, and mirror checkbox changes in the shared application JS so the preference survives even before submit.

Keep auth-cookie semantics unchanged: checked login stays persistent, unchecked login stays browser-session only.

Add regression coverage for the new cookie contract and update the UI and HTMX architecture references to document the split between auth lifetime and login-form preference state.