### PR TITLE
refactor(cookies): unify cookie ownership across server and browser

### DIFF
--- a/docs/4-ui-reference.md
+++ b/docs/4-ui-reference.md
@@ -315,6 +315,9 @@ Cookie ownership is split intentionally:
 - `http/cookie_session.py` owns the session cookie transport contract such as
    the cookie name, SameSite default, secret resolution, and request-scope
    override helpers.
+- `http/ui_cookies.py` owns browser-readable non-auth UI cookie names, shared
+   low-level parsing helpers, and the raw `Set-Cookie` formatting reused by
+   UI views.
 
 ### Session keys
 
@@ -364,16 +367,21 @@ The UI uses two cookie families with different ownership and lifecycles:
 ### UI state cookie lifecycle
 
 UI state cookies are intentionally separate from the signed session payload.
-They are written by page-specific JS or server helpers because they do not
+They are written through shared server or browser helpers because they do not
 carry authentication state:
 
-- `theme` is written by `static/js/application.js` and controls light/dark
-   presentation. The same cookie is read during full-page renders so the server
-   can emit the matching theme before first paint.
+- `theme` is written through `writeUiCookie()` in `static/js/application.js`
+   and controls light or dark presentation. The same cookie is read during
+   full-page renders so the server can emit the matching theme before first
+   paint.
 - `login_remember_me` is written by `POST /login` and mirrored by
-   `static/js/application.js` when the checkbox changes. It keeps the login
-   form's explicit opt-out state across browser restarts without changing the
-   signed auth-cookie lifetime.
+   `static/js/application.js` through the shared browser cookie helper when the
+   checkbox changes. It keeps the login form's explicit opt-out state across
+   browser restarts without changing the signed auth-cookie lifetime.
+- `master_only` is mirrored by the shared checkbox-cookie handler in
+   `static/js/application.js` using `data-ui-cookie-*` attributes from
+   `nns_content_fragment.html.j2`. The `/nns` form also submits an explicit
+   false fallback so unchecked htmx requests do not depend on cookie timing.
 - `contributors_findme` is written by `static/js/contributors.js` and preserves
    rank-jump mode across contributors pages.
 - `machines_state` is written by `static/js/tests_homepage.js` and preserves
@@ -381,8 +389,9 @@ carry authentication state:
    triggers an immediate `/tests/machines` refresh instead of waiting for the
    next periodic poll.
 - `machines_sort`, `machines_order`, `machines_page`, `machines_q`,
-   and `machines_my_workers` are written server-side by `views_machines.py`
-   when `/tests/machines` normalizes the current filter state.
+   and `machines_my_workers` are written server-side through
+   `http/ui_cookies.py` from `views_machines.py` when `/tests/machines`
+   normalizes the current filter state.
 - `active_run_filters` is written by `static/js/active_run_filters.js` and
    preserves the Active runs filter selection across the three dimensions
    (test type, time control, and threads).
@@ -721,7 +730,8 @@ Behavior notes:
   order aligned with the other card pages: cards, text, filters, view switch,
   pagination, table, pagination.
 - `master_only` checkbox preference is persisted in a cookie and reused when
-   the query parameter is not present.
+   the query parameter is not present. The form also submits an explicit false
+   fallback so unchecked htmx requests and cookie persistence stay aligned.
 - Table sorting is fully server-authoritative; there is no client-side header
    sorter.
 

--- a/docs/5-templates.md
+++ b/docs/5-templates.md
@@ -216,12 +216,12 @@ Design rules:
 - **`autocomplete="off"`** on all search/filter text inputs to prevent
   browser autofill from interfering with htmx-driven filtering.
 - **Cookie max-age** must use `UI_STATE_COOKIE_MAX_AGE_SECONDS` from
-  `settings.py`, never hardcoded values. Client-side cookies set via
-  `hx-on::before-request` handlers use the Jinja variable
-   `{{ cookie_max_age }}` backed by this constant. This is the single max-age
-   owner for non-auth UI cookies; templates should expose
-   `cookies.ui_state_max_age` or a page-specific `cookie_max_age` context
-   instead of introducing alternate aliases or literals.
+   `settings.py`, never hardcoded values. Client-side cookies must flow through
+   the shared `writeUiCookie()` helper in `application.js` or through template
+   `data-*` attributes consumed by that helper. This is the single max-age owner
+   for non-auth UI cookies; templates should expose `cookies.ui_state_max_age`
+   or a page-specific `cookie_max_age` context instead of introducing alternate
+   aliases or literals.
 
 Known gaps documented for future iterations:
 
@@ -404,8 +404,9 @@ Behavior notes:
    later visits.
 - `login.html.j2` defaults `remember_me_cookie_name` to `login_remember_me`
    because the same template is also used for generic UI 403 rendering.
-- `application.js` mirrors checkbox changes into the same UI-state cookie, and
-   `POST /login` refreshes it server-side for progressive enhancement.
+- `application.js` mirrors checkbox changes into the same UI-state cookie via
+   `writeUiCookie()`, and `POST /login` refreshes it server-side for
+   progressive enhancement.
 
 ### `machines_fragment.html.j2`
 
@@ -457,6 +458,9 @@ Behavior notes:
    htmx requests, while submit remains available as a non-JS fallback.
 - `network_name` and `user` are literal case-insensitive substring filters;
    regex metacharacters are escaped before reaching Mongo.
+- `nns_content_fragment.html.j2` pairs a hidden `master_only=0` field with the
+   checkbox `value="1"` and `data-ui-cookie-*` attributes, so unchecked htmx
+   requests and cookie persistence stay synchronized without inline JS.
 - The page shell owns the heading and filter form; the summary cards,
   explanatory copy, view toggle, pagination, and table live in the content
   fragment.

--- a/server/fishtest/http/ui_cookies.py
+++ b/server/fishtest/http/ui_cookies.py
@@ -1,0 +1,111 @@
+"""Shared helpers for non-auth UI cookies.
+
+These helpers keep the browser-readable cookie contract in one place while
+preserving the existing raw ``Set-Cookie`` append behavior used by the UI.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableSequence
+from typing import Any, Final, Protocol, cast
+from urllib.parse import quote, unquote
+
+ACTIVE_RUN_FILTERS_COOKIE_NAME: Final[str] = "active_run_filters"
+ACTIVE_RUN_FILTERS_PANEL_COOKIE_NAME: Final[str] = "active_run_filters_panel"
+CONTRIBUTORS_FINDME_COOKIE_NAME: Final[str] = "contributors_findme"
+LIVE_ELO_MODE_COOKIE_NAME: Final[str] = "live_elo_mode"
+LOGIN_REMEMBER_ME_COOKIE_NAME: Final[str] = "login_remember_me"
+MACHINES_MY_WORKERS_COOKIE_NAME: Final[str] = "machines_my_workers"
+MACHINES_ORDER_COOKIE_NAME: Final[str] = "machines_order"
+MACHINES_PAGE_COOKIE_NAME: Final[str] = "machines_page"
+MACHINES_QUERY_COOKIE_NAME: Final[str] = "machines_q"
+MACHINES_SORT_COOKIE_NAME: Final[str] = "machines_sort"
+MACHINES_STATE_COOKIE_NAME: Final[str] = "machines_state"
+MASTER_ONLY_COOKIE_NAME: Final[str] = "master_only"
+TASKS_ORDER_COOKIE_NAME: Final[str] = "tasks_order"
+TASKS_QUERY_COOKIE_NAME: Final[str] = "tasks_q"
+TASKS_SORT_COOKIE_NAME: Final[str] = "tasks_sort"
+TASKS_STATE_COOKIE_NAME: Final[str] = "tasks_state"
+TASKS_VIEW_COOKIE_NAME: Final[str] = "tasks_view"
+THEME_COOKIE_NAME: Final[str] = "theme"
+
+UI_COOKIE_PATH: Final[str] = "/"
+UI_COOKIE_SAMESITE: Final[str] = "Lax"
+
+_COOKIE_TRUE_VALUES = frozenset({"1", "true", "on", "yes"})
+_TOGGLE_COOKIE_VALUES = frozenset({"Hide", "Show"})
+
+
+class _CookieReader(Protocol):
+    cookies: Mapping[str, Any]
+
+
+class _CookieWriter(_CookieReader, Protocol):
+    response_headerlist: MutableSequence[tuple[str, str]]
+
+
+def _cookie_source(source: _CookieReader | Mapping[str, Any]) -> Mapping[str, Any]:
+    if isinstance(source, Mapping):
+        return cast("Mapping[str, Any]", source)
+    return source.cookies
+
+
+def build_ui_cookie_header(name: str, value: str, *, max_age_seconds: int) -> str:
+    """Return the raw Set-Cookie value for a browser-readable UI cookie."""
+    encoded_value = quote(str(value), safe="")
+    return (
+        f"{name}={encoded_value}; path={UI_COOKIE_PATH}; "
+        f"max-age={max_age_seconds}; SameSite={UI_COOKIE_SAMESITE}"
+    )
+
+
+def append_ui_cookie(
+    request: _CookieWriter,
+    name: str,
+    value: str,
+    *,
+    max_age_seconds: int,
+) -> None:
+    """Append a UI cookie header without collapsing duplicate Set-Cookie lines."""
+    # Preserve duplicate Set-Cookie headers so UI-state cookies can coexist
+    # with the signed session cookie on the same response.
+    request.response_headerlist.append(
+        (
+            "Set-Cookie",
+            build_ui_cookie_header(name, value, max_age_seconds=max_age_seconds),
+        ),
+    )
+
+
+def read_cookie_text(
+    source: _CookieReader | Mapping[str, Any],
+    name: str,
+    default: str = "",
+) -> str:
+    """Read and URL-decode a cookie value as normalized text."""
+    raw_value = _cookie_source(source).get(name, default)
+    return unquote(str(raw_value)).strip()
+
+
+def read_cookie_bool(
+    source: _CookieReader | Mapping[str, Any],
+    name: str,
+    *,
+    default: bool = False,
+) -> bool:
+    """Interpret a browser-readable cookie as a conventional truthy flag."""
+    raw_value = read_cookie_text(source, name)
+    if not raw_value:
+        return default
+    return raw_value.lower() in _COOKIE_TRUE_VALUES
+
+
+def read_cookie_toggle_state(
+    source: _CookieReader | Mapping[str, Any],
+    name: str,
+    *,
+    default: str = "Show",
+) -> str:
+    """Return a validated Show or Hide toggle cookie value."""
+    raw_value = read_cookie_text(source, name)
+    return raw_value if raw_value in _TOGGLE_COOKIE_VALUES else default

--- a/server/fishtest/static/js/active_run_filters.js
+++ b/server/fishtest/static/js/active_run_filters.js
@@ -88,7 +88,7 @@
   };
 
   const restoreState = () => {
-    const raw = getCookie(cookieName);
+    const raw = readUiCookie(cookieName);
     if (!raw) {
       return;
     }
@@ -122,11 +122,11 @@
     if (!Number.isFinite(cookieMaxAge) || cookieMaxAge <= 0) {
       return;
     }
-    document.cookie = `${cookieName}=${value}; path=/; max-age=${cookieMaxAge}; SameSite=Lax`;
+    writeUiCookie(cookieName, value, cookieMaxAge);
   };
 
   const clearCookie = () => {
-    document.cookie = `${cookieName}=; path=/; max-age=0; SameSite=Lax`;
+    clearUiCookie(cookieName);
   };
 
   const syncAllCheckbox = () => {
@@ -285,7 +285,7 @@
     toggleBtn.setAttribute("aria-expanded", String(visible));
   };
 
-  if (getCookie(toggleCookieName) === "hidden") {
+  if (readUiCookie(toggleCookieName) === "hidden") {
     setPanel(false);
   }
 
@@ -293,9 +293,9 @@
     const isVisible = !filterPanel.hidden;
     setPanel(!isVisible);
     if (isVisible) {
-      setStateCookie(toggleCookieName, "hidden", cookieMaxAge);
+      writeUiCookie(toggleCookieName, "hidden", cookieMaxAge);
     } else {
-      document.cookie = `${toggleCookieName}=; path=/; max-age=0; SameSite=Lax`;
+      clearUiCookie(toggleCookieName);
     }
   });
 

--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -11,6 +11,7 @@ let broadcastDispatch = {
   handleModalFocusManagement();
   protectForms();
   handlePanelToggleCookies();
+  handleCheckboxUiCookies();
   handleApplicationLogout();
   handleApplicationThemes();
   handleLoginRememberMePreference();
@@ -78,15 +79,31 @@ function protectForms() {
   });
 }
 
-// Gets from the browser the value of a saved cookie
-function getCookie(cookieName) {
-  return document.cookie
+// Gets from the browser the value of a saved cookie.
+function readUiCookie(cookieName) {
+  if (!cookieName) {
+    return "";
+  }
+
+  const key = `${cookieName}=`;
+  const cookiePart = document.cookie
     .split(";")
-    .map((cookie) => cookie.trim().split("="))
-    .find(([name]) => name === cookieName)?.[1];
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(key));
+
+  if (!cookiePart) {
+    return "";
+  }
+
+  const rawValue = cookiePart.slice(key.length);
+  try {
+    return decodeURIComponent(rawValue);
+  } catch {
+    return rawValue;
+  }
 }
 
-function setStateCookie(name, value, maxAgeSeconds) {
+function writeUiCookie(name, value, maxAgeSeconds) {
   if (!name) {
     return;
   }
@@ -95,7 +112,46 @@ function setStateCookie(name, value, maxAgeSeconds) {
     return;
   }
   // Keep UI state cookies available across all pages that reuse the same panels.
-  document.cookie = `${name}=${value}; path=/; max-age=${maxAge}; SameSite=Lax`;
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${maxAge}; SameSite=Lax`;
+}
+
+function clearUiCookie(name) {
+  if (!name) {
+    return;
+  }
+  document.cookie = `${name}=; path=/; max-age=0; SameSite=Lax`;
+}
+
+function syncCheckboxUiCookie(checkbox) {
+  if (!(checkbox instanceof HTMLInputElement) || checkbox.type !== "checkbox") {
+    return;
+  }
+
+  const cookieName = checkbox.dataset.uiCookieName;
+  if (!cookieName) {
+    return;
+  }
+
+  const maxAge =
+    checkbox.dataset.uiCookieMaxAge || window.uiStateCookieMaxAgeSeconds;
+  const checkedValue = checkbox.dataset.uiCookieCheckedValue || "true";
+  const uncheckedValue = checkbox.dataset.uiCookieUncheckedValue || "false";
+
+  writeUiCookie(
+    cookieName,
+    checkbox.checked ? checkedValue : uncheckedValue,
+    maxAge,
+  );
+}
+
+function handleCheckboxUiCookies() {
+  document.addEventListener(
+    "change",
+    (event) => {
+      syncCheckboxUiCookie(event.target);
+    },
+    true,
+  );
 }
 
 function handlePanelToggleCookies() {
@@ -114,7 +170,7 @@ function handlePanelToggleCookies() {
     const nextState = active ? "Show" : "Hide";
 
     button.textContent = nextState;
-    setStateCookie(cookieName, nextState, maxAge);
+    writeUiCookie(cookieName, nextState, maxAge);
   });
 }
 
@@ -129,7 +185,7 @@ function handleLoginRememberMePreference() {
     checkbox.dataset.rememberMeCookieMaxAge ||
     window.uiStateCookieMaxAgeSeconds;
   checkbox.addEventListener("change", () => {
-    setStateCookie(cookieName, checkbox.checked ? "1" : "0", maxAge);
+    writeUiCookie(cookieName, checkbox.checked ? "1" : "0", maxAge);
   });
 }
 
@@ -144,7 +200,7 @@ function formatBytes(bytes) {
 }
 
 function handleApplicationThemes() {
-  if (!getCookie("theme")) {
+  if (!readUiCookie("theme")) {
     setTheme(mediaTheme());
   }
 
@@ -195,7 +251,7 @@ function setTheme(theme) {
     document.documentElement.style.colorScheme = "";
     darkLink?.remove();
   }
-  setStateCookie("theme", theme, window.uiStateCookieMaxAgeSeconds);
+  writeUiCookie("theme", theme, window.uiStateCookieMaxAgeSeconds);
 }
 
 function supportsNotifications() {

--- a/server/fishtest/static/js/contributors.js
+++ b/server/fishtest/static/js/contributors.js
@@ -15,16 +15,7 @@
     if (!Number.isFinite(cookieMaxAge) || cookieMaxAge <= 0) {
       return;
     }
-    document.cookie = `${cookieName}=${value}; path=/; max-age=${cookieMaxAge}; SameSite=Lax`;
-  };
-
-  const getCookie = (name) => {
-    const key = `${name}=`;
-    const match = document.cookie
-      .split(";")
-      .map((part) => part.trim())
-      .find((part) => part.startsWith(key));
-    return match ? match.slice(key.length) : "";
+    writeUiCookie(cookieName, value, cookieMaxAge);
   };
 
   const centerHighlightedContributor = () => {
@@ -44,7 +35,7 @@
   ) {
     const params = new URLSearchParams(window.location.search);
     const findmeFromUrl = params.get("findme") === "1";
-    const remembered = getCookie(cookieName);
+    const remembered = readUiCookie(cookieName);
 
     if (remembered === "false") {
       findme.checked = false;

--- a/server/fishtest/static/js/live_elo.js
+++ b/server/fishtest/static/js/live_elo.js
@@ -90,15 +90,8 @@
     return raw === ELO_MODE_DYNAMIC ? ELO_MODE_DYNAMIC : ELO_MODE_FIXED;
   }
 
-  function getCookie(name) {
-    return document.cookie
-      .split(";")
-      .map((cookie) => cookie.trim().split("="))
-      .find(([cookieName]) => cookieName === name)?.[1];
-  }
-
   function initialEloMode(gauge) {
-    const persistedMode = getCookie(ELO_MODE_COOKIE_NAME);
+    const persistedMode = readUiCookie(ELO_MODE_COOKIE_NAME);
     if (
       persistedMode === ELO_MODE_FIXED ||
       persistedMode === ELO_MODE_DYNAMIC
@@ -112,7 +105,7 @@
     if (!Number.isFinite(eloModeCookieMaxAge) || eloModeCookieMaxAge <= 0) {
       return;
     }
-    document.cookie = `${ELO_MODE_COOKIE_NAME}=${mode}; path=/; max-age=${eloModeCookieMaxAge}; SameSite=Lax`;
+    writeUiCookie(ELO_MODE_COOKIE_NAME, mode, eloModeCookieMaxAge);
   }
 
   function isTerminalSprtState(state) {

--- a/server/fishtest/static/js/tests_homepage.js
+++ b/server/fishtest/static/js/tests_homepage.js
@@ -21,7 +21,7 @@
     button.textContent = nextState;
     button.setAttribute("aria-expanded", String(isExpanded));
     if (Number.isFinite(toggleCookieMaxAge) && toggleCookieMaxAge > 0) {
-      document.cookie = `machines_state=${nextState}; path=/; max-age=${toggleCookieMaxAge}; SameSite=Lax`;
+      writeUiCookie("machines_state", nextState, toggleCookieMaxAge);
     }
   };
 

--- a/server/fishtest/templates/nns_content_fragment.html.j2
+++ b/server/fishtest/templates/nns_content_fragment.html.j2
@@ -87,11 +87,11 @@
   hx-push-url="true"
   hx-swap="innerHTML"
   hx-trigger="submit, input changed delay:{{ htmx.input_changed_delay_ms }}ms from:#network_name, input changed delay:{{ htmx.input_changed_delay_ms }}ms from:#user, search from:#network_name, search from:#user, change from:#master_only"
-  hx-on::before-request="document.cookie = 'master_only=' + (document.getElementById('master_only').checked ? 'true' : 'false') + '; path=/; max-age={{ cookie_max_age }}; SameSite=Lax'"
 >
   <input type="hidden" id="nns_view" name="view" value="{{ view }}">
   <input type="hidden" id="nns_sort" name="sort" value="{{ sort }}">
   <input type="hidden" id="nns_order" name="order" value="{{ order }}">
+  <input type="hidden" name="master_only" value="0">
 
   <div class="col-12 col-md-auto mb-3">
     <label for="network_name" class="form-label">Network</label>
@@ -127,6 +127,9 @@
         class="form-check-input"
         id="master_only"
         name="master_only"
+        value="1"
+        data-ui-cookie-name="master_only"
+        data-ui-cookie-max-age="{{ cookie_max_age }}"
         {{ 'checked' if master_only else '' }}
       >
     </div>

--- a/server/fishtest/templates/tests_view.html.j2
+++ b/server/fishtest/templates/tests_view.html.j2
@@ -390,7 +390,7 @@
 ></script>
 
 <script>
-  let cookieTheme = getCookie("theme");
+  let cookieTheme = readUiCookie("theme");
   const currentTime = new Date().getTime();
   const oneDayAgo = currentTime - (24 * 60 * 60 * 1000); // 24 hours ago in milliseconds
 
@@ -550,7 +550,7 @@
     btn?.addEventListener("click", () => {
       const active = btn.textContent.trim() === "Hide";
       btn.textContent = active ? "Show" : "Hide";
-      setStateCookie(
+      writeUiCookie(
         "tasks_state",
         btn.textContent.trim(),
         btn.dataset.toggleCookieMaxAge,

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, TypedDict
-from urllib.parse import quote, unquote, urlencode
+from urllib.parse import quote, urlencode
 
 import bson
 import regex
@@ -82,6 +82,26 @@ from fishtest.http.template_helpers import (
     tests_run_setup,
 )
 from fishtest.http.template_renderer import render_template_to_response
+from fishtest.http.ui_cookies import (
+    ACTIVE_RUN_FILTERS_COOKIE_NAME,
+    LOGIN_REMEMBER_ME_COOKIE_NAME,
+    MACHINES_MY_WORKERS_COOKIE_NAME,
+    MACHINES_ORDER_COOKIE_NAME,
+    MACHINES_PAGE_COOKIE_NAME,
+    MACHINES_QUERY_COOKIE_NAME,
+    MACHINES_SORT_COOKIE_NAME,
+    MACHINES_STATE_COOKIE_NAME,
+    MASTER_ONLY_COOKIE_NAME,
+    TASKS_ORDER_COOKIE_NAME,
+    TASKS_QUERY_COOKIE_NAME,
+    TASKS_SORT_COOKIE_NAME,
+    TASKS_STATE_COOKIE_NAME,
+    TASKS_VIEW_COOKIE_NAME,
+    append_ui_cookie,
+    read_cookie_bool,
+    read_cookie_text,
+    read_cookie_toggle_state,
+)
 from fishtest.http.ui_pipeline import apply_http_cache
 from fishtest.run_cache import Prio
 from fishtest.schemas import (
@@ -166,7 +186,6 @@ _MAX_NETWORK_SIZE_BYTES = 200_000_000
 _THROUGHPUT_NORMAL_LIMIT = 100
 _MIN_BOOK_EXITS = 100_000
 _RUN_AGE_GITHUB_API_MAX_DAYS = 30
-_LOGIN_REMEMBER_ME_COOKIE_NAME = "login_remember_me"
 _LOGIN_REMEMBER_ME_TRUE_VALUES = frozenset({"1", "true", "on", "yes"})
 _LOGIN_REMEMBER_ME_FALSE_VALUES = frozenset({"0", "false", "off", "no"})
 
@@ -301,7 +320,7 @@ def _build_active_run_filter_context(
     active_runs: list[dict],
 ) -> _ActiveRunFilterContext:
     enabled_by_dim = _parse_active_run_filter_cookie(
-        request.cookies.get("active_run_filters", ""),
+        read_cookie_text(request, ACTIVE_RUN_FILTERS_COOKIE_NAME),
     )
     hidden_selectors: list[str] = []
     style_text = ""
@@ -571,24 +590,8 @@ def ensure_logged_in(request: _ViewContext) -> str | RedirectResponse:
     return userid
 
 
-def _set_ui_state_cookie(
-    request: _ViewContext,
-    name: str,
-    value: str,
-    max_age_seconds: int,
-) -> None:
-    cookie_value = (
-        f"{name}={quote(value, safe='')}; path=/; max-age={max_age_seconds}; "
-        "SameSite=Lax"
-    )
-    # Keep duplicate Set-Cookie headers intact so UI-state cookies can coexist
-    # with the signed session cookie on the same response.
-    request.response_headerlist.append(("Set-Cookie", cookie_value))
-
-
 def _login_remember_me_checked(request: _ViewContext) -> bool:
-    raw_value = str(request.cookies.get(_LOGIN_REMEMBER_ME_COOKIE_NAME, ""))
-    cookie_value = raw_value.strip().lower()
+    cookie_value = read_cookie_text(request, LOGIN_REMEMBER_ME_COOKIE_NAME).lower()
     if cookie_value in _LOGIN_REMEMBER_ME_FALSE_VALUES:
         return False
     if cookie_value in _LOGIN_REMEMBER_ME_TRUE_VALUES:
@@ -596,7 +599,7 @@ def _login_remember_me_checked(request: _ViewContext) -> bool:
     return True
 
 
-def _login_remember_me_checked_from_form(post_data: Any) -> bool:
+def _login_remember_me_checked_from_form(post_data: object) -> bool:
     submitted_values: list[str] = []
     getlist = getattr(post_data, "getlist", None)
     if callable(getlist):
@@ -604,7 +607,8 @@ def _login_remember_me_checked_from_form(post_data: Any) -> bool:
             str(value).strip().lower() for value in getlist("stay_logged_in")
         ]
     else:
-        raw_value = post_data.get("stay_logged_in")
+        get = getattr(post_data, "get", None)
+        raw_value = get("stay_logged_in") if callable(get) else None
         if raw_value is not None:
             submitted_values = [str(raw_value).strip().lower()]
 
@@ -621,11 +625,11 @@ def _set_login_remember_me_cookie(
     *,
     remember_me_checked: bool,
 ) -> None:
-    _set_ui_state_cookie(
+    append_ui_cookie(
         request,
-        _LOGIN_REMEMBER_ME_COOKIE_NAME,
+        LOGIN_REMEMBER_ME_COOKIE_NAME,
         "1" if remember_me_checked else "0",
-        UI_STATE_COOKIE_MAX_AGE_SECONDS,
+        max_age_seconds=UI_STATE_COOKIE_MAX_AGE_SECONDS,
     )
 
 
@@ -671,7 +675,7 @@ def login(request: _ViewContext) -> dict[str, Any] | RedirectResponse:
         request.session.flash(message, "error")
     return {
         "remember_me_checked": remember_me_checked,
-        "remember_me_cookie_name": _LOGIN_REMEMBER_ME_COOKIE_NAME,
+        "remember_me_cookie_name": LOGIN_REMEMBER_ME_COOKIE_NAME,
     }
 
 
@@ -1285,11 +1289,19 @@ def nns(request: _ViewContext) -> dict[str, Any] | Response:  # noqa: C901, PLR0
             return value
         return str(value).strip().lower() in {"1", "true", "on", "yes"}
 
-    master_only_param = request.params.get("master_only")
-    if master_only_param is None:
-        master_only = _truthy(request.cookies.get("master_only", "false"))
+    master_only_values: list[Any] = []
+    getlist = getattr(request.params, "getlist", None)
+    if callable(getlist):
+        master_only_values = getlist("master_only")
     else:
-        master_only = _truthy(master_only_param)
+        master_only_param = request.params.get("master_only")
+        if master_only_param is not None:
+            master_only_values = [master_only_param]
+
+    if master_only_values:
+        master_only = any(_truthy(value) for value in master_only_values)
+    else:
+        master_only = read_cookie_bool(request, MASTER_ONLY_COOKIE_NAME)
 
     page_idx = 0
     page_param = request.params.get("page", "")
@@ -1991,7 +2003,10 @@ def _build_toggle_states(
     request: _ViewContext,
     toggle_names: list[str],
 ) -> dict[str, str]:
-    return {name: request.cookies.get(f"{name}_state", "Show") for name in toggle_names}
+    return {
+        name: read_cookie_toggle_state(request, f"{name}_state")
+        for name in toggle_names
+    }
 
 
 def _is_tests_run_tables_live_request(request: _ViewContext) -> bool:
@@ -2290,25 +2305,25 @@ def tests(request: _ViewContext) -> dict[str, Any] | Response:
 
     authenticated_user = request.authenticated_userid
 
-    machines_sort = request.cookies.get("machines_sort", "").strip().lower()
+    machines_sort = read_cookie_text(request, MACHINES_SORT_COOKIE_NAME).lower()
     if machines_sort not in _MACHINES_SORT_MAP:
         machines_sort = _MACHINES_DEFAULT_SORT
 
     _, machines_default_reverse = _MACHINES_SORT_MAP[machines_sort]
-    machines_order = request.cookies.get("machines_order", "").strip().lower()
+    machines_order = read_cookie_text(request, MACHINES_ORDER_COOKIE_NAME).lower()
     if machines_order not in {"asc", "desc"}:
         machines_order = "desc" if machines_default_reverse else "asc"
 
-    machines_q = unquote(request.cookies.get("machines_q", ""))
+    machines_q = read_cookie_text(request, MACHINES_QUERY_COOKIE_NAME)
 
-    machines_page_raw = request.cookies.get("machines_page", "")
+    machines_page_raw = read_cookie_text(request, MACHINES_PAGE_COOKIE_NAME)
     if machines_page_raw.isdigit() and int(machines_page_raw) >= 1:
         machines_page = int(machines_page_raw)
     else:
         machines_page = 1
 
     machines_my_workers = _is_truthy_param(
-        request.cookies.get("machines_my_workers", ""),
+        read_cookie_text(request, MACHINES_MY_WORKERS_COOKIE_NAME),
     )
     if not authenticated_user:
         machines_my_workers = False
@@ -2339,7 +2354,11 @@ def tests(request: _ViewContext) -> dict[str, Any] | Response:
 
     return {
         **last_tests,
-        "machines_shown": request.cookies.get("machines_state") == "Hide",
+        "machines_shown": read_cookie_toggle_state(
+            request,
+            MACHINES_STATE_COOKIE_NAME,
+        )
+        == "Hide",
         "workers_count_text": workers_count,
         "machines_sort": machines_sort,
         "machines_order": machines_order,
@@ -2964,10 +2983,6 @@ _TASKS_PAGE_SIZE = TASKS_PAGE_SIZE
 _TASKS_MAX_ALL = TASKS_MAX_ALL
 
 
-def _tasks_cookie_value(request: _ViewContext, name: str) -> str:
-    return unquote(str(request.cookies.get(name, ""))).strip()
-
-
 def _parse_show_task_param(request: _ViewContext) -> int:
     try:
         show_task = int(request.params.get("show_task", -1))
@@ -2984,7 +2999,7 @@ def _task_filter_value(
 ) -> str:
     raw_value = request.params.get(param_name)
     if raw_value is None:
-        raw_value = _tasks_cookie_value(request, cookie_name)
+        raw_value = read_cookie_text(request, cookie_name)
     return str(raw_value).strip()
 
 
@@ -3027,7 +3042,7 @@ def _task_table_state(
 
     raw_sort = request.params.get("sort")
     if raw_sort is None:
-        raw_sort = _tasks_cookie_value(request, "tasks_sort")
+        raw_sort = read_cookie_text(request, TASKS_SORT_COOKIE_NAME)
     sort_param = str(raw_sort).strip().lower() or _TASKS_DEFAULT_SORT
     if sort_param not in _TASKS_SORT_MAP:
         sort_param = _TASKS_DEFAULT_SORT
@@ -3036,19 +3051,19 @@ def _task_table_state(
     order_param, reverse = _normalize_sort_order(
         request.params.get("order")
         if request.params.get("order") is not None
-        else _tasks_cookie_value(request, "tasks_order"),
+        else read_cookie_text(request, TASKS_ORDER_COOKIE_NAME),
         default_reverse=default_reverse,
     )
 
     raw_view = request.params.get("view")
     if raw_view is None:
-        raw_view = _tasks_cookie_value(request, "tasks_view")
+        raw_view = read_cookie_text(request, TASKS_VIEW_COOKIE_NAME)
     view_param = _normalize_view_mode(raw_view or "paged")
 
     query_filter = _task_filter_value(
         request,
         param_name="q",
-        cookie_name="tasks_q",
+        cookie_name=TASKS_QUERY_COOKIE_NAME,
     )
 
     tasks.sort(
@@ -3129,24 +3144,35 @@ def _task_table_state(
     }
 
 
-def _set_tasks_cookie(
-    request: _ViewContext,
-    name: str,
-    value: str,
-    max_age_seconds: int,
-) -> None:
-    _set_ui_state_cookie(request, name, value, max_age_seconds)
-
-
 def _set_tasks_cookies(
     request: _ViewContext,
     state: dict[str, Any],
 ) -> None:
     cookie_max_age = UI_STATE_COOKIE_MAX_AGE_SECONDS
-    _set_tasks_cookie(request, "tasks_sort", str(state["sort"]), cookie_max_age)
-    _set_tasks_cookie(request, "tasks_order", str(state["order"]), cookie_max_age)
-    _set_tasks_cookie(request, "tasks_view", str(state["view"]), cookie_max_age)
-    _set_tasks_cookie(request, "tasks_q", str(state["q"]), cookie_max_age)
+    append_ui_cookie(
+        request,
+        TASKS_SORT_COOKIE_NAME,
+        str(state["sort"]),
+        max_age_seconds=cookie_max_age,
+    )
+    append_ui_cookie(
+        request,
+        TASKS_ORDER_COOKIE_NAME,
+        str(state["order"]),
+        max_age_seconds=cookie_max_age,
+    )
+    append_ui_cookie(
+        request,
+        TASKS_VIEW_COOKIE_NAME,
+        str(state["view"]),
+        max_age_seconds=cookie_max_age,
+    )
+    append_ui_cookie(
+        request,
+        TASKS_QUERY_COOKIE_NAME,
+        str(state["q"]),
+        max_age_seconds=cookie_max_age,
+    )
 
 
 def _format_tests_view_spsa_value(
@@ -3660,7 +3686,7 @@ def tests_view(request: _ViewContext) -> dict[str, Any] | RedirectResponse:  # n
         "page_title": page_title,
         "results_info": results_info,
         "tasks_shown": tasks_table_context["show_task"] != -1
-        or request.cookies.get("tasks_state") == "Hide",
+        or read_cookie_toggle_state(request, TASKS_STATE_COOKIE_NAME) == "Hide",
         "show_task": tasks_table_context["show_task"],
         "tasks_sort": tasks_table_context["sort"],
         "tasks_order": tasks_table_context["order"],

--- a/server/fishtest/views_machines.py
+++ b/server/fishtest/views_machines.py
@@ -8,11 +8,19 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any
-from urllib.parse import quote, unquote
 
 from fishtest.http.settings import (
     MACHINES_PAGE_SIZE,
     UI_STATE_COOKIE_MAX_AGE_SECONDS,
+)
+from fishtest.http.ui_cookies import (
+    MACHINES_MY_WORKERS_COOKIE_NAME,
+    MACHINES_ORDER_COOKIE_NAME,
+    MACHINES_PAGE_COOKIE_NAME,
+    MACHINES_QUERY_COOKIE_NAME,
+    MACHINES_SORT_COOKIE_NAME,
+    append_ui_cookie,
+    read_cookie_text,
 )
 from fishtest.util import format_time_ago, worker_name
 from fishtest.views_helpers import (
@@ -133,7 +141,7 @@ def _machine_filter_state(
 ) -> dict[str, Any]:
     query_filter = query_source.get(query_key, "")
     if use_cookies:
-        query_filter = unquote(str(query_filter))
+        query_filter = read_cookie_text(query_source, query_key)
     query_filter = str(query_filter).strip()
 
     my_workers = _is_truthy_param(query_source.get(my_workers_key, ""))
@@ -236,21 +244,6 @@ def _build_machines_query_params(
     )
 
 
-def _set_machine_cookie(
-    request: Any,  # noqa: ANN401
-    name: str,
-    value: str,
-    max_age_seconds: int,
-) -> None:
-    encoded = quote(str(value), safe="")
-    request.response_headerlist.append(
-        (
-            "Set-Cookie",
-            f"{name}={encoded}; path=/; max-age={max_age_seconds}; SameSite=Lax",
-        ),
-    )
-
-
 def _set_machine_cookies(  # noqa: PLR0913
     request: Any,  # noqa: ANN401
     *,
@@ -261,15 +254,35 @@ def _set_machine_cookies(  # noqa: PLR0913
     my_workers: bool,
 ) -> None:
     cookie_max_age = UI_STATE_COOKIE_MAX_AGE_SECONDS
-    _set_machine_cookie(request, "machines_sort", sort_param, cookie_max_age)
-    _set_machine_cookie(request, "machines_order", order_param, cookie_max_age)
-    _set_machine_cookie(request, "machines_page", str(page), cookie_max_age)
-    _set_machine_cookie(request, "machines_q", query_filter, cookie_max_age)
-    _set_machine_cookie(
+    append_ui_cookie(
         request,
-        "machines_my_workers",
+        MACHINES_SORT_COOKIE_NAME,
+        sort_param,
+        max_age_seconds=cookie_max_age,
+    )
+    append_ui_cookie(
+        request,
+        MACHINES_ORDER_COOKIE_NAME,
+        order_param,
+        max_age_seconds=cookie_max_age,
+    )
+    append_ui_cookie(
+        request,
+        MACHINES_PAGE_COOKIE_NAME,
+        str(page),
+        max_age_seconds=cookie_max_age,
+    )
+    append_ui_cookie(
+        request,
+        MACHINES_QUERY_COOKIE_NAME,
+        query_filter,
+        max_age_seconds=cookie_max_age,
+    )
+    append_ui_cookie(
+        request,
+        MACHINES_MY_WORKERS_COOKIE_NAME,
         "1" if my_workers else "0",
-        cookie_max_age,
+        max_age_seconds=cookie_max_age,
     )
 
 

--- a/server/tests/test_http_ui_cookies.py
+++ b/server/tests/test_http_ui_cookies.py
@@ -1,0 +1,59 @@
+"""Test shared browser-readable UI cookie helpers."""
+
+import unittest
+from types import SimpleNamespace
+
+from fishtest.http.ui_cookies import (
+    append_ui_cookie,
+    build_ui_cookie_header,
+    read_cookie_bool,
+    read_cookie_text,
+    read_cookie_toggle_state,
+)
+
+
+class UiCookieHelperTests(unittest.TestCase):
+    def test_build_ui_cookie_header_uses_shared_attrs_and_encoding(self):
+        header = build_ui_cookie_header(
+            "machines_q",
+            "linux worker/1",
+            max_age_seconds=10,
+        )
+
+        self.assertEqual(
+            header,
+            "machines_q=linux%20worker%2F1; path=/; max-age=10; SameSite=Lax",
+        )
+
+    def test_append_ui_cookie_preserves_duplicate_set_cookie_headers(self):
+        request = SimpleNamespace(cookies={}, response_headerlist=[])
+
+        append_ui_cookie(request, "theme", "dark", max_age_seconds=10)
+        append_ui_cookie(request, "theme", "light", max_age_seconds=10)
+
+        self.assertEqual(len(request.response_headerlist), 2)
+        self.assertEqual(request.response_headerlist[0][0], "Set-Cookie")
+        self.assertEqual(request.response_headerlist[1][0], "Set-Cookie")
+        self.assertIn("theme=dark", request.response_headerlist[0][1])
+        self.assertIn("theme=light", request.response_headerlist[1][1])
+
+    def test_read_cookie_text_decodes_percent_escaped_values(self):
+        self.assertEqual(
+            read_cookie_text({"machines_q": "linux%20worker%2F1"}, "machines_q"),
+            "linux worker/1",
+        )
+
+    def test_read_cookie_bool_uses_truthy_values_and_default(self):
+        self.assertTrue(read_cookie_bool({"master_only": "yes"}, "master_only"))
+        self.assertFalse(read_cookie_bool({"master_only": "off"}, "master_only"))
+        self.assertTrue(read_cookie_bool({}, "master_only", default=True))
+
+    def test_read_cookie_toggle_state_only_accepts_show_or_hide(self):
+        self.assertEqual(
+            read_cookie_toggle_state({"tasks_state": "Hide"}, "tasks_state"),
+            "Hide",
+        )
+        self.assertEqual(
+            read_cookie_toggle_state({"tasks_state": "hidden"}, "tasks_state"),
+            "Show",
+        )

--- a/server/tests/test_nn.py
+++ b/server/tests/test_nn.py
@@ -6,7 +6,10 @@ from datetime import UTC, datetime
 import test_support
 from vtjson import ValidationError
 
-from fishtest.http.settings import HTMX_INPUT_CHANGED_DELAY_MS
+from fishtest.http.settings import (
+    HTMX_INPUT_CHANGED_DELAY_MS,
+    UI_STATE_COOKIE_MAX_AGE_SECONDS,
+)
 
 
 def show(mc):
@@ -107,9 +110,41 @@ class TestNNViews(unittest.TestCase):
         )
         self.assertNotIn(">Search</button>", response.text)
         self.assertIn('type="search"', response.text)
-        self.assertIn("hx-on::before-request", response.text)
-        self.assertIn("path=/;", response.text)
+        self.assertIn('type="hidden" name="master_only" value="0"', response.text)
+        self.assertIn('data-ui-cookie-name="master_only"', response.text)
+        self.assertIn(
+            f'data-ui-cookie-max-age="{UI_STATE_COOKIE_MAX_AGE_SECONDS}"',
+            response.text,
+        )
+        self.assertNotIn("hx-on::before-request", response.text)
+        self.assertNotIn("document.cookie =", response.text)
         self.assertNotIn('getElementById("search_nn").addEventListener', response.text)
+
+    def test_nns_master_only_cookie_fallback_filters_results(self):
+        docs = [
+            {
+                "name": "nn-h16-cookie-master.nnue",
+                "user": "CookieUploader",
+                "downloads": 8,
+                "is_master": True,
+            },
+            {
+                "name": "nn-h16-cookie-other.nnue",
+                "user": "CookieUploader",
+                "downloads": 1,
+                "is_master": False,
+            },
+        ]
+        self.rundb.nndb.insert_many(docs)
+
+        response = self.client.get(
+            "/nns?network_name=nn-h16-cookie&view=all",
+            headers={"cookie": "master_only=true"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("nn-h16-cookie-master.nnue", response.text)
+        self.assertNotIn("nn-h16-cookie-other.nnue", response.text)
 
     def test_nns_server_side_search_hx_fragment(self):
         hit_name = "nn-h16-hit.nnue"

--- a/server/tests/test_views_contributors.py
+++ b/server/tests/test_views_contributors.py
@@ -473,7 +473,9 @@ class TestViewsContributors(UiUserTestCase):
         )
         js_source = js_path.read_text(encoding="utf-8")
 
-        self.assertIn("path=/; max-age=${cookieMaxAge}; SameSite=Lax", js_source)
+        self.assertIn("writeUiCookie(cookieName, value, cookieMaxAge);", js_source)
+        self.assertIn("readUiCookie(cookieName)", js_source)
+        self.assertNotIn("document.cookie =", js_source)
         self.assertNotIn(
             "path=/contributors; max-age=${cookieMaxAge}; SameSite=Lax",
             js_source,


### PR DESCRIPTION
Centralize the current non-auth UI cookie contract so server and browser code share one explicit home for naming, formatting, and parsing.

Replace duplicated page-local cookie reads and writes with shared helpers, while keeping browser-only callers on a migration seam for future storage changes.

Preserve first-paint behavior and the signed auth session boundary, but keep hardening follow-ups such as Secure/Host-prefix, Fetch Metadata, and session-rotation review explicitly separate.

Document the cookie families, ownership boundaries, compatibility invariants, and validation flow.