### PR TITLE
fix(http): accept float-coercible action timestamps in Open Graph helper

### DIFF
--- a/server/fishtest/http/open_graph.py
+++ b/server/fishtest/http/open_graph.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, SupportsFloat, TypedDict
 from urllib.parse import urlsplit, urlunsplit
 
 from fishtest.http.template_helpers import nelo_pentanomial_summary_text
@@ -15,6 +15,8 @@ _SITE_NAME = "Stockfish Testing Framework"
 _DEFAULT_DESCRIPTION = "Distributed testing framework for the Stockfish chess engine."
 _TITLE_SUFFIX = " | Stockfish Testing"
 _YELLOW_THEME_COLOR = "#FFFF00"
+
+_TimestampInput = SupportsFloat | str | None
 
 
 class OpenGraphMetadata(TypedDict):
@@ -113,7 +115,7 @@ def _build_page_open_graph(
     return open_graph
 
 
-def _metadata_time_label(value: int | float | str | None) -> str:
+def _metadata_time_label(value: _TimestampInput) -> str:
     if value is None:
         return ""
 

--- a/server/tests/test_http_open_graph.py
+++ b/server/tests/test_http_open_graph.py
@@ -179,3 +179,22 @@ class OpenGraphTests(unittest.TestCase):
         self.assertIn("user=alice", open_graph["description"])
         self.assertIn("text=clang", open_graph["description"])
         self.assertIn("run=69d12ae19caf4559aa7ada3e", open_graph["description"])
+
+    def test_build_actions_open_graph_formats_integer_timestamps(self):
+        open_graph = build_actions_open_graph(
+            page_url="https://example.org/actions?user=alice",
+            actions=[
+                {
+                    "time": 1775675144,
+                    "event": "worker_log",
+                    "agent_name": "worker-a",
+                    "target_name": "run-a/3",
+                    "message": "integer timestamp from stored action data",
+                }
+            ],
+            num_actions=1,
+            filters={"action": "", "username": "", "text": "", "run_id": ""},
+            run_id_filter="",
+        )
+
+        self.assertIn("Time: 26-04-08 19:05:44", open_graph["description"])


### PR DESCRIPTION
Type the action timestamp formatter as SupportsFloat | str | None so Mongo-backed integer timestamps remain valid without reintroducing the redundant int | float union rejected by strict lint.

Add focused Open Graph coverage for integer action timestamps to lock the accepted timestamp boundary.