### PR TITLE
refactor(server): centralize classic SPSA flow

### DIFF
--- a/docs/1-architecture.md
+++ b/docs/1-architecture.md
@@ -36,7 +36,8 @@ server/
 |   |-- schemas.py           -- vtjson validation schemas
 |   |-- run_cache.py         -- In-memory run cache with dirty-page flush
 |   |-- lru_cache.py         -- Generic LRU cache
-|   |-- spsa_handler.py      -- SPSA tuning parameter handler
+|   |-- spsa_workflow.py     -- Pure classic SPSA lifecycle helpers
+|   |-- spsa_handler.py      -- SPSA worker orchestration, request/update flow, history buffering
 |   |-- github_api.py        -- GitHub integration (commit metadata, branch resolution)
 |   |-- util.py              -- Shared utilities (formatting, validation helpers)
 |   |-- __init__.py          -- Minimal package init
@@ -53,6 +54,12 @@ shim stay centralized there. Each extracted `views_*.py` module keeps a matching
 dedicated test file under `server/tests/`. User-facing route-family UI tests
 reuse `ui_user_test_case.py` and stay grouped by route family or one focused
 UI motif.
+
+Classic SPSA server ownership is split deliberately. `spsa_workflow.py` holds
+the pure classic SPSA helpers reused by the run form, the detail page, and the
+worker lifecycle. `spsa_handler.py` stays attached to `RunDb` and owns the
+stateful worker request/update path, flip packing, buffering, and history
+timing.
 
 ### HTTP support modules (`server/fishtest/http/`)
 

--- a/docs/5-templates.md
+++ b/docs/5-templates.md
@@ -868,7 +868,10 @@ Shared SPSA chart section for the test detail page.
 Rendered structure:
 
 - `#tests-view-spsa` root element
-- DOM-embedded `application/json` payload for the current SPSA state
+- DOM-embedded `application/json` payload for the current SPSA state,
+   exposing `param_names` plus server-shaped `chart_rows`; those chart rows
+   fold together the start row, compact sampled history rows, and the current
+   live point, with `c_values` present when `% c` mode can be rendered
 - cookie-backed `% c` checkbox rendered from `spsa_percentage_checked`
 - `#spsa_history_scroll` retained scroll container
 - CSS-owned `#spsa_history_plot` shell for the fixed-size chart (Google Charts uses 1000x500; layout and scrolling handled by CSS and the scroll container)

--- a/docs/9-references.md
+++ b/docs/9-references.md
@@ -466,6 +466,7 @@ validation fails.
 | `test_views_helpers.py` | Shared pagination, parameter, and merge helpers |
 | `test_views_machines.py` | Machines helper behavior plus `/tests/machines` HTTP contracts |
 | `test_views_run.py` | Run-form validation, SPSA parsing, permissions, and run action routes |
+| `test_spsa_workflow.py` | Shared classic SPSA form, worker update, and chart-payload helper contracts |
 | `test_http_boundary.py` | HTTP boundary invariants and template contracts |
 | `test_http_dependencies.py` | Request-state dependency wiring |
 | `test_http_errors.py` | API vs UI error shaping |

--- a/server/fishtest/http/boundary.py
+++ b/server/fishtest/http/boundary.py
@@ -44,8 +44,11 @@ class _SessionFlags(Protocol):
 
 
 class _SessionUser(_SessionFlags, Protocol):
-    raw_request: Request | None
-    session: CookieSession | dict[str, object]
+    @property
+    def raw_request(self) -> Request | None: ...
+
+    @property
+    def session(self) -> CookieSession | dict[str, object]: ...
 
 
 @dataclass(frozen=True, slots=True)

--- a/server/fishtest/http/ui_cookies.py
+++ b/server/fishtest/http/ui_cookies.py
@@ -38,11 +38,13 @@ _TOGGLE_COOKIE_VALUES = frozenset({"Hide", "Show"})
 
 
 class _CookieReader(Protocol):
-    cookies: Mapping[str, Any]
+    @property
+    def cookies(self) -> Mapping[str, Any]: ...
 
 
 class _CookieWriter(_CookieReader, Protocol):
-    response_headerlist: MutableSequence[tuple[str, str]]
+    @property
+    def response_headerlist(self) -> MutableSequence[tuple[str, str]]: ...
 
 
 def _cookie_source(source: _CookieReader | Mapping[str, Any]) -> Mapping[str, Any]:

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -793,6 +793,7 @@ runs_schema = intersect(
                     one_of("overshoot", "lost_samples"),
                 ),
                 "spsa?": {
+                    "algorithm?": "classic",
                     "A": unumber,
                     "alpha": unumber,
                     "gamma": unumber,

--- a/server/fishtest/spsa_handler.py
+++ b/server/fishtest/spsa_handler.py
@@ -3,6 +3,14 @@ import zlib
 
 import numpy as np
 
+from fishtest.spsa_workflow import (
+    apply_spsa_result_updates,
+    build_spsa_chart_payload,
+    build_spsa_worker_step,
+    clip_spsa_param_value,
+    get_spsa_history_period,
+)
+
 
 def _pack_flips(flips):
     """
@@ -23,35 +31,31 @@ def _unpack_flips(packed_flips, length=None):
     return flips.tolist() if length is None else flips[:length].tolist()
 
 
-def _param_clip(param, increment):
-    return min(max(param["theta"] + increment, param["min"]), param["max"])
-
-
 def _generate_data(spsa, iter=None):
     result = {"w_params": [], "b_params": []}
 
     if iter is None:
         iter = spsa["iter"]
 
-    # Generate a set of tuning parameters
-    iter_local = iter + 1  # start from 1 to avoid division by zero
     for param in spsa["params"]:
-        c = param["c"] / iter_local ** spsa["gamma"]
         flip = random.choice((-1, 1))
+        worker_step = build_spsa_worker_step(
+            spsa,
+            param,
+            iter_value=iter,
+            flip=flip,
+        )
         result["w_params"].append(
             {
                 "name": param["name"],
-                "value": _param_clip(param, c * flip),
-                "R": param["a"] / (spsa["A"] + iter_local) ** spsa["alpha"] / c**2,
-                "c": c,
-                "flip": flip,
+                "value": clip_spsa_param_value(param, worker_step["c"] * flip),
+                **worker_step,
             }
         )
-        # These are only used by the worker
         result["b_params"].append(
             {
                 "name": param["name"],
-                "value": _param_clip(param, -c * flip),
+                "value": clip_spsa_param_value(param, -worker_step["c"] * flip),
             }
         )
 
@@ -59,20 +63,25 @@ def _generate_data(spsa, iter=None):
 
 
 def _add_to_history(spsa, num_games, w_params):
-    # Compute the update frequency so that the required storage does not depend
-    # on the the number of parameters. We have to recompute this every time since
-    # the user may have modified the run.
     n_params = len(spsa["params"])
-    samples = 100 if n_params < 100 else 10000 / n_params if n_params < 1000 else 1
-    period = num_games / 2 / samples
+    period = get_spsa_history_period(num_iter=num_games / 2, param_count=n_params)
 
-    # Now update if the time has come...
+    if len(spsa["params"]) != len(w_params):
+        msg = (
+            "SPSA history length mismatch: "
+            f"{len(spsa['params'])} params, {len(w_params)} worker params"
+        )
+        raise ValueError(msg)
+
+    if period <= 0:
+        return
+
     if "param_history" not in spsa:
         spsa["param_history"] = []
     if len(spsa["param_history"]) + 1 <= spsa["iter"] / period:
         summary = [
             {"theta": spsa_param["theta"], "R": w_param["R"], "c": w_param["c"]}
-            for w_param, spsa_param in zip(w_params, spsa["params"])
+            for spsa_param, w_param in zip(spsa["params"], w_params)
         ]
         spsa["param_history"].append(summary)
 
@@ -148,15 +157,16 @@ class SPSAHandler:
             w_param["flip"] = flips[idx]
             del w_param["value"]  # for safety!
 
-        # Update the current theta based on the results from the worker
         result = spsa_results["wins"] - spsa_results["losses"]
-        spsa["iter"] += spsa_results["num_games"] // 2
+        game_pairs = spsa_results["num_games"] // 2
+        spsa["iter"] += game_pairs
 
-        for idx, param in enumerate(spsa["params"]):
-            R = w_params[idx]["R"]
-            c = w_params[idx]["c"]
-            flip = w_params[idx]["flip"]
-            param["theta"] = _param_clip(param, R * c * result * flip)
+        apply_spsa_result_updates(
+            spsa,
+            w_params,
+            result=result,
+            game_pairs=game_pairs,
+        )
 
         _add_to_history(spsa, run["args"]["num_games"], w_params)
 
@@ -164,4 +174,4 @@ class SPSAHandler:
 
     def get_spsa_data(self, run_id):
         run = self.get_run(run_id)
-        return run["args"].get("spsa", {})
+        return build_spsa_chart_payload(run["args"].get("spsa"))

--- a/server/fishtest/spsa_workflow.py
+++ b/server/fishtest/spsa_workflow.py
@@ -1,0 +1,594 @@
+"""Share classic SPSA lifecycle behavior across form, worker, and chart code."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from math import isclose, isfinite
+from typing import Any
+
+CLASSIC_SPSA_ALGORITHM = "classic"
+
+_CLASSIC_SPSA_FORM_DEFAULTS = {
+    "algorithm": CLASSIC_SPSA_ALGORITHM,
+    "A": 0.1,
+    "alpha": 0.602,
+    "gamma": 0.101,
+    "raw_params": "",
+}
+_SPSA_PARAM_FIELDS = 6
+
+
+def _as_float(value: object, fallback: float | None = None) -> float | None:
+    try:
+        return float(value)
+    except TypeError, ValueError:
+        return fallback
+
+
+def _finite_float(value: object, fallback: float | None = None) -> float | None:
+    number = _as_float(value)
+    if number is None or not isfinite(number):
+        return fallback
+    return number
+
+
+def _require_spsa_number(
+    value: object,
+    *,
+    field_name: str,
+    line_number: int | None = None,
+    minimum: float | None = None,
+    strict_minimum: bool = False,
+) -> float:
+    number = _finite_float(value)
+    location = (
+        f"line {line_number} field {field_name}"
+        if line_number is not None
+        else field_name
+    )
+    if number is None:
+        msg = f"Invalid SPSA {location}: expected a finite number"
+        raise ValueError(msg)
+
+    if minimum is None:
+        return number
+
+    if strict_minimum:
+        if number <= minimum:
+            msg = f"Invalid SPSA {location}: expected a finite number > {minimum:g}"
+            raise ValueError(msg)
+        return number
+
+    if number < minimum:
+        msg = f"Invalid SPSA {location}: expected a finite number >= {minimum:g}"
+        raise ValueError(msg)
+
+    return number
+
+
+def _chart_numbers_match(left: object, right: object) -> bool:
+    left_number = _finite_float(left)
+    right_number = _finite_float(right)
+    if left_number is None or right_number is None:
+        return False
+
+    return isclose(left_number, right_number, rel_tol=0.0, abs_tol=1e-9)
+
+
+def _chart_sample_matches(
+    sample: list[dict[str, float | None]] | None,
+    live_sample: list[dict[str, float | None]],
+) -> bool:
+    if sample is None or not sample or len(sample) != len(live_sample):
+        return False
+
+    return all(
+        _chart_numbers_match(sample_param.get("theta"), live_param.get("theta"))
+        and _chart_numbers_match(sample_param.get("c"), live_param.get("c"))
+        for sample_param, live_param in zip(sample, live_sample)
+    )
+
+
+def _recover_chart_sample_iter(
+    sample: list[dict[str, float | None]],
+    params: list[Mapping[str, Any]],
+    *,
+    gamma: float,
+) -> float | None:
+    if not isfinite(gamma) or gamma <= 0:
+        return None
+
+    recovered_iters: list[float] = []
+    for param, sample_param in zip(params, sample):
+        base_c = _finite_float(param.get("c"))
+        sample_c = _finite_float(sample_param.get("c"))
+        if base_c is None or sample_c is None or base_c <= 0 or sample_c <= 0:
+            continue
+
+        iter_local = (base_c / sample_c) ** (1.0 / gamma)
+        if not isfinite(iter_local) or iter_local <= 0:
+            continue
+
+        recovered_iters.append(max(iter_local - 1.0, 0.0))
+
+    if not recovered_iters:
+        return None
+
+    recovered_iters.sort()
+    middle = len(recovered_iters) // 2
+    if len(recovered_iters) % 2:
+        return recovered_iters[middle]
+
+    return (recovered_iters[middle - 1] + recovered_iters[middle]) / 2.0
+
+
+def _build_master_fallback_history_iters(
+    history_len: int,
+    *,
+    iter_value: float,
+    num_iter: float,
+    has_live_point: bool,
+) -> list[float]:
+    total_points = history_len + int(has_live_point)
+    if total_points <= 0:
+        return []
+
+    final_iter_ratio = (
+        min(max(iter_value / num_iter, 0.0), 1.0) if num_iter > 0 else 0.0
+    )
+    return [
+        (index + 1) / total_points * final_iter_ratio * num_iter
+        for index in range(history_len)
+    ]
+
+
+def _build_chart_history_iters(
+    params: list[Mapping[str, Any]],
+    chart_history: list[list[dict[str, float | None]]],
+    *,
+    gamma: float,
+    iter_value: float,
+    num_iter: float,
+    has_live_point: bool,
+) -> list[float]:
+    recovered_history_iters: list[float] = []
+    for sample in chart_history:
+        sample_iter = _recover_chart_sample_iter(sample, params, gamma=gamma)
+        if sample_iter is None:
+            return _build_master_fallback_history_iters(
+                len(chart_history),
+                iter_value=iter_value,
+                num_iter=num_iter,
+                has_live_point=has_live_point,
+            )
+
+        if iter_value > 0:
+            sample_iter = min(max(sample_iter, 0.0), iter_value)
+        else:
+            sample_iter = max(sample_iter, 0.0)
+
+        if (
+            recovered_history_iters
+            and sample_iter + 1.0e-9 < recovered_history_iters[-1]
+        ):
+            return _build_master_fallback_history_iters(
+                len(chart_history),
+                iter_value=iter_value,
+                num_iter=num_iter,
+                has_live_point=has_live_point,
+            )
+
+        recovered_history_iters.append(sample_iter)
+
+    return recovered_history_iters
+
+
+def _build_spsa_chart_rows(
+    params: list[Mapping[str, Any]],
+    chart_history: list[list[dict[str, float | None]]],
+    live_point: list[dict[str, float | None]],
+    *,
+    gamma: float,
+    iter_value: float,
+    num_iter: float,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    start_values: list[float] = []
+    for param in params:
+        start_value = _finite_float(
+            param.get("start"),
+            _finite_float(param.get("theta"), 0.0),
+        )
+        start_values.append(start_value if start_value is not None else 0.0)
+
+    rows.append({"iter_ratio": 0.0, "values": start_values})
+
+    if not chart_history:
+        return rows
+
+    has_live_point = not _chart_sample_matches(chart_history[-1], live_point)
+    history_iters = _build_chart_history_iters(
+        params,
+        chart_history,
+        gamma=gamma,
+        iter_value=iter_value,
+        num_iter=num_iter,
+        has_live_point=has_live_point,
+    )
+
+    if (
+        history_iters
+        and iter_value > 0
+        and _chart_sample_matches(chart_history[-1], live_point)
+    ):
+        history_iters[-1] = iter_value
+
+    current_values = start_values.copy()
+    for sample, sample_iter in zip(chart_history, history_iters):
+        row_values: list[float] = []
+        c_values: list[float | None] = []
+        for index, current_value in enumerate(current_values):
+            sample_param = sample[index] if index < len(sample) else None
+            next_value = (
+                _finite_float(sample_param.get("theta"), current_value)
+                if sample_param is not None
+                else current_value
+            )
+            current_values[index] = (
+                next_value if next_value is not None else current_value
+            )
+            row_values.append(current_values[index])
+            c_values.append(
+                _finite_float(sample_param.get("c"))
+                if sample_param is not None
+                else None
+            )
+
+        rows.append(
+            {
+                "iter_ratio": min(max(sample_iter / num_iter, 0.0), 1.0)
+                if num_iter > 0
+                else 0.0,
+                "values": row_values,
+                "c_values": c_values,
+            }
+        )
+
+    if iter_value <= 0 or not has_live_point:
+        return rows
+
+    rows.append(
+        {
+            "iter_ratio": min(max(iter_value / num_iter, 0.0), 1.0)
+            if num_iter > 0
+            else 0.0,
+            "values": [
+                live_param["theta"]
+                if live_param.get("theta") is not None
+                else start_value
+                for live_param, start_value in zip(live_point, start_values)
+            ],
+            "c_values": [live_param.get("c") for live_param in live_point],
+        }
+    )
+    return rows
+
+
+def _normalize_algorithm_name(name: object) -> str:
+    if name == CLASSIC_SPSA_ALGORITHM:
+        return CLASSIC_SPSA_ALGORITHM
+    msg = f"Unknown SPSA algorithm: {name}"
+    raise ValueError(msg)
+
+
+def _read_spsa_algorithm_name(spsa: Mapping[str, Any] | None) -> str:
+    if not isinstance(spsa, Mapping):
+        return CLASSIC_SPSA_ALGORITHM
+
+    algorithm = spsa.get("algorithm")
+    if algorithm is None:
+        return CLASSIC_SPSA_ALGORITHM
+
+    return _normalize_algorithm_name(algorithm)
+
+
+def clip_spsa_param_value(param: Mapping[str, Any], increment: float) -> float:
+    return min(max(param["theta"] + increment, param["min"]), param["max"])
+
+
+def get_spsa_history_period(*, num_iter: int | float, param_count: int) -> float:
+    if num_iter <= 0 or param_count <= 0:
+        return 0.0
+
+    samples = (
+        100 if param_count < 100 else 10000 / param_count if param_count < 1000 else 1
+    )
+    return float(num_iter) / samples
+
+
+def build_spsa_form_values(
+    spsa: Mapping[str, Any] | None,
+    *,
+    num_games: int | None = None,
+) -> dict[str, Any]:
+    _read_spsa_algorithm_name(spsa)
+
+    values = dict(_CLASSIC_SPSA_FORM_DEFAULTS)
+    if not isinstance(spsa, Mapping):
+        return values
+
+    values["raw_params"] = str(spsa.get("raw_params", values["raw_params"]))
+    for field in ("A", "alpha", "gamma"):
+        field_value = _finite_float(spsa.get(field))
+        if field_value is not None:
+            values[field] = field_value
+
+    if isinstance(num_games, int) and num_games > 0:
+        stored_A = _finite_float(spsa.get("A"))
+        if stored_A is not None:
+            values["A"] = round(1000 * 2 * stored_A / num_games) / 1000
+
+    return values
+
+
+def build_spsa_state(
+    post: Mapping[str, Any],
+    *,
+    num_games: int,
+) -> dict[str, Any]:
+    algorithm_name = _normalize_algorithm_name(
+        post.get("spsa_algorithm", CLASSIC_SPSA_ALGORITHM),
+    )
+    A_ratio = _require_spsa_number(
+        post["spsa_A"],
+        field_name="A ratio",
+        minimum=0.0,
+    )
+    alpha = _require_spsa_number(
+        post["spsa_alpha"],
+        field_name="alpha",
+        minimum=0.0,
+    )
+    gamma = _require_spsa_number(
+        post["spsa_gamma"],
+        field_name="gamma",
+        minimum=0.0,
+    )
+    spsa: dict[str, Any] = {
+        "algorithm": algorithm_name,
+        "A": int(A_ratio * num_games / 2),
+        "alpha": alpha,
+        "gamma": gamma,
+        "raw_params": str(post["spsa_raw_params"]),
+        "iter": 0,
+        "num_iter": num_games // 2,
+    }
+    spsa["params"] = parse_spsa_params(spsa)
+    return spsa
+
+
+def parse_spsa_params(spsa: dict[str, Any]) -> list[dict[str, Any]]:
+    _read_spsa_algorithm_name(spsa)
+
+    A = _require_spsa_number(spsa.get("A"), field_name="A", minimum=0.0)
+    alpha = _require_spsa_number(
+        spsa.get("alpha"),
+        field_name="alpha",
+        minimum=0.0,
+    )
+    gamma = _require_spsa_number(
+        spsa.get("gamma"),
+        field_name="gamma",
+        minimum=0.0,
+    )
+    num_iter = _require_spsa_number(
+        spsa.get("num_iter"),
+        field_name="num_iter",
+        minimum=0.0,
+    )
+    raw = spsa["raw_params"]
+    params = []
+    for line_number, line in enumerate(raw.split("\n"), start=1):
+        chunks = line.strip().split(",")
+        if len(chunks) == 1 and chunks[0] == "":
+            continue
+        if len(chunks) != _SPSA_PARAM_FIELDS:
+            msg = f"the line {chunks} does not have {_SPSA_PARAM_FIELDS} entries"
+            raise ValueError(msg)
+        param = {
+            "name": chunks[0],
+            "start": _require_spsa_number(
+                chunks[1],
+                field_name="start",
+                line_number=line_number,
+            ),
+            "min": _require_spsa_number(
+                chunks[2],
+                field_name="min",
+                line_number=line_number,
+            ),
+            "max": _require_spsa_number(
+                chunks[3],
+                field_name="max",
+                line_number=line_number,
+            ),
+            "c_end": _require_spsa_number(
+                chunks[4],
+                field_name="c_end",
+                line_number=line_number,
+                minimum=0.0,
+                strict_minimum=True,
+            ),
+            "r_end": _require_spsa_number(
+                chunks[5],
+                field_name="r_end",
+                line_number=line_number,
+                minimum=0.0,
+            ),
+        }
+        param["c"] = param["c_end"] * num_iter**gamma
+        param["a_end"] = param["r_end"] * param["c_end"] ** 2
+        param["a"] = param["a_end"] * (A + num_iter) ** alpha
+        param["theta"] = param["start"]
+        params.append(param)
+    return params
+
+
+def format_spsa_value(
+    spsa: Mapping[str, Any],
+    *,
+    logger: logging.Logger | None = None,
+    run_id: str | None = None,
+) -> list[str | list[str]]:
+    _read_spsa_algorithm_name(spsa)
+
+    iter_local = spsa["iter"] + 1
+    A = spsa["A"]
+    alpha = spsa["alpha"]
+    gamma = spsa["gamma"]
+    summary = (
+        f"iter: {iter_local:d}, A: {A:d}, alpha: {alpha:0.3f}, gamma: {gamma:0.3f}"
+    )
+    spsa_value: list[str | list[str]] = [summary]
+    for param in spsa["params"]:
+        try:
+            c_iter = param["c"] / (iter_local**gamma)
+            r_iter = param["a"] / (A + iter_local) ** alpha / c_iter**2
+        except (ArithmeticError, TypeError, ValueError) as error:
+            if logger is not None and run_id is not None:
+                logger.warning(
+                    "Invalid SPSA param state while rendering "
+                    "run %s (iter=%d, param=%s): %s",
+                    run_id,
+                    iter_local,
+                    param.get("name", "<unknown>"),
+                    error,
+                )
+            c_iter = float("nan")
+            r_iter = float("nan")
+        spsa_value.append(
+            [
+                param["name"],
+                "{:.2f}".format(param["theta"]),
+                str(int(param["start"])),
+                str(int(param["min"])),
+                str(int(param["max"])),
+                f"{c_iter:.3f}",
+                "{:.3f}".format(param["c_end"]),
+                f"{r_iter:.2e}",
+                "{:.2e}".format(param["r_end"]),
+            ],
+        )
+    return spsa_value
+
+
+def build_spsa_worker_step(
+    spsa: Mapping[str, Any],
+    param: Mapping[str, Any],
+    *,
+    iter_value: int,
+    flip: int,
+) -> dict[str, Any]:
+    _read_spsa_algorithm_name(spsa)
+
+    iter_local = iter_value + 1
+    c = param["c"] / iter_local ** spsa["gamma"]
+    return {
+        "c": c,
+        "R": param["a"] / (spsa["A"] + iter_local) ** spsa["alpha"] / c**2,
+        "flip": flip,
+    }
+
+
+def apply_spsa_result_updates(
+    spsa: dict[str, Any],
+    w_params: list[dict[str, Any]],
+    *,
+    result: int,
+    game_pairs: int,
+) -> None:
+    _read_spsa_algorithm_name(spsa)
+    del game_pairs
+
+    if len(spsa["params"]) != len(w_params):
+        msg = (
+            "SPSA parameter update length mismatch: "
+            f"{len(spsa['params'])} params, {len(w_params)} worker params"
+        )
+        raise ValueError(msg)
+
+    for param, w_param in zip(spsa["params"], w_params):
+        param["theta"] = clip_spsa_param_value(
+            param,
+            w_param["R"] * w_param["c"] * result * w_param["flip"],
+        )
+
+
+def build_spsa_chart_payload(spsa: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(spsa, Mapping):
+        return {}
+
+    _read_spsa_algorithm_name(spsa)
+    iter_value = _finite_float(spsa.get("iter"), 0.0)
+    iter_local = iter_value + 1.0
+    gamma = _finite_float(spsa.get("gamma"), 0.0)
+    num_iter = _finite_float(spsa.get("num_iter"), 0.0)
+
+    params: list[Mapping[str, Any]] = []
+    param_names: list[str] = []
+    live_point: list[dict[str, float | None]] = []
+    for param in spsa.get("params", []):
+        if not isinstance(param, Mapping):
+            continue
+        params.append(param)
+        param_names.append(str(param.get("name", "")))
+        theta = _finite_float(param.get("theta"), 0.0)
+        base_c = _finite_float(param.get("c"))
+        live_c = None
+        if base_c is not None:
+            try:
+                live_c = _finite_float(base_c / iter_local**gamma)
+            except ArithmeticError, OverflowError, ValueError:
+                live_c = None
+        live_point.append(
+            {
+                "theta": theta if theta is not None else 0.0,
+                "c": live_c,
+            }
+        )
+
+    param_history = spsa.get("param_history")
+    chart_history: list[list[dict[str, Any]]] = []
+    if isinstance(param_history, list):
+        for sample in param_history:
+            if not isinstance(sample, list):
+                continue
+
+            normalized_params: list[dict[str, Any]] = []
+            for sample_param in sample:
+                if not isinstance(sample_param, Mapping):
+                    continue
+                normalized_params.append(
+                    {
+                        "theta": _finite_float(sample_param.get("theta")),
+                        "c": _finite_float(sample_param.get("c")),
+                    }
+                )
+
+            if not normalized_params:
+                continue
+
+            chart_history.append(normalized_params)
+
+    return {
+        "param_names": param_names,
+        "chart_rows": _build_spsa_chart_rows(
+            params,
+            chart_history,
+            live_point,
+            gamma=gamma if gamma is not None else 0.0,
+            iter_value=iter_value,
+            num_iter=num_iter if num_iter is not None else 0.0,
+        ),
+    }

--- a/server/fishtest/static/js/spsa.js
+++ b/server/fishtest/static/js/spsa.js
@@ -284,60 +284,28 @@ async function handleSPSA() {
   }
 
   function buildData(nextSmoothingFactor) {
-    const spsaParams = spsaData.params;
-    const spsaHistory = spsaData.param_history;
-    const numIter = asFiniteNumber(spsaData.num_iter, 0);
-    const iterValue = asFiniteNumber(spsaData.iter, 0);
-    const gamma = asFiniteNumber(spsaData.gamma, 0);
-    const spsaIterRatio =
-      numIter > 0 ? Math.min(Math.max(iterValue / numIter, 0), 1) : 0;
+    const paramNames = spsaData.param_names;
+    const chartRows = spsaData.chart_rows;
+    const finalIterRatio = asFiniteNumber(
+      chartRows.length > 0 ? chartRows[chartRows.length - 1]?.iter_ratio : 0,
+      0,
+    );
 
     if (!dataCache[0]) {
       const dt0 = new google.visualization.DataTable();
       dt0.addColumn("number", "Iteration");
-      for (let i = 0; i < spsaParams.length; i += 1) {
-        dt0.addColumn("number", spsaParams[i].name);
+      for (const paramName of paramNames) {
+        dt0.addColumn("number", paramName);
       }
 
-      const nParams = spsaParams.length;
-      const samples =
-        nParams < 100 ? 100 : nParams < 1000 ? 10000 / nParams : 1;
-      const period = numIter > 0 ? Math.max(numIter / samples, 1) : 0;
-      const hasLivePoint =
-        spsaHistory.length > 0 &&
-        period > 0 &&
-        iterValue > spsaHistory.length * period;
-      const totalPoints = spsaHistory.length + (hasLivePoint ? 1 : 0);
-
-      const lastValues = spsaParams.map((param) =>
-        asFiniteNumber(param.start, asFiniteNumber(param.theta, 0)),
+      dt0.addRows(
+        chartRows.map((row) => [
+          asFiniteNumber(row?.iter_ratio, 0),
+          ...paramNames.map((_, index) =>
+            asFiniteNumber(row?.values?.[index], 0),
+          ),
+        ]),
       );
-      const unsmoothedData = [];
-      for (let i = 0; i <= totalPoints; i += 1) {
-        const rowData = [
-          totalPoints > 0 ? (i / totalPoints) * spsaIterRatio : 0,
-        ];
-        for (let j = 0; j < spsaParams.length; j += 1) {
-          if (i === 0) {
-            rowData.push(lastValues[j]);
-            continue;
-          }
-
-          if (hasLivePoint && i === totalPoints) {
-            rowData.push(asFiniteNumber(spsaParams[j].theta, lastValues[j]));
-            continue;
-          }
-
-          const nextValue = asFiniteNumber(
-            spsaHistory[i - 1]?.[j]?.theta,
-            lastValues[j],
-          );
-          rowData.push(nextValue);
-          lastValues[j] = nextValue;
-        }
-        unsmoothedData.push(rowData);
-      }
-      dt0.addRows(unsmoothedData);
       dataCache[0] = dt0;
     }
 
@@ -345,15 +313,15 @@ async function handleSPSA() {
       const dt0 = dataCache[0];
       const dt = new google.visualization.DataTable();
       dt.addColumn("number", "Iteration");
-      for (let i = 0; i < spsaParams.length; i += 1) {
-        dt.addColumn("number", spsaParams[i].name);
+      for (const paramName of paramNames) {
+        dt.addColumn("number", paramName);
       }
 
       const bandwidth =
-        spsaHistory.length > 0 && spsaIterRatio > 0
+        chartRows.length > 1 && finalIterRatio > 0
           ? 2 *
             nextSmoothingFactor *
-            (spsaHistory.length / (spsaIterRatio * 100))
+            ((chartRows.length - 1) / (finalIterRatio * 100))
           : 0;
       const rawArrays = [];
       for (let col = 1; col < dt0.getNumberOfColumns(); col += 1) {
@@ -386,22 +354,19 @@ async function handleSPSA() {
       const view = new google.visualization.DataView(chartData);
       view.setColumns([
         0,
-        ...spsaParams.map((_, i) => ({
+        ...paramNames.map((paramName, i) => ({
           calc: (dt, row) => {
             if (row === 0) {
               return 0;
             }
-            const cValue =
-              row <= spsaHistory.length
-                ? Number(spsaHistory[row - 1]?.[i]?.c)
-                : Number(spsaParams[i]?.c) / Math.pow(iterValue + 1, gamma);
+            const cValue = Number(chartRows[row]?.c_values?.[i]);
             if (!Number.isFinite(cValue) || cValue === 0) {
               return null;
             }
             return (dt.getValue(row, i + 1) - dt.getValue(0, i + 1)) / cValue;
           },
           type: "number",
-          label: spsaParams[i].name,
+          label: paramName,
         })),
       ]);
       chartData = view;
@@ -427,7 +392,7 @@ async function handleSPSA() {
 
   function rebuildDropdown(dropdown) {
     const fragment = document.createDocumentFragment();
-    for (let j = 0; j < spsaData.params.length; j += 1) {
+    for (let j = 0; j < spsaData.param_names.length; j += 1) {
       const dropdownItem = document.createElement("li");
       const anchorItem = document.createElement("a");
       anchorItem.className = "dropdown-item";
@@ -436,7 +401,7 @@ async function handleSPSA() {
       }
       anchorItem.href = "#";
       anchorItem.dataset.paramId = j + 1;
-      anchorItem.append(spsaData.params[j].name);
+      anchorItem.append(spsaData.param_names[j]);
       dropdownItem.append(anchorItem);
       fragment.append(dropdownItem);
     }
@@ -453,11 +418,10 @@ async function handleSPSA() {
     }
 
     spsaData = {
-      ...nextData,
-      params: Array.isArray(nextData.params) ? nextData.params : [],
-      param_history: Array.isArray(nextData.param_history)
-        ? nextData.param_history
+      param_names: Array.isArray(nextData.param_names)
+        ? nextData.param_names
         : [],
+      chart_rows: Array.isArray(nextData.chart_rows) ? nextData.chart_rows : [],
     };
     dataCache.length = 0;
     chartData = null;
@@ -478,10 +442,10 @@ async function handleSPSA() {
       });
     }
 
-    if (!spsaData.param_history.length) {
+    if (spsaData.chart_rows.length <= 1) {
       chartToolbar.style.display = "none";
       showSPSAAlert(
-        spsaData.params.length >= 1000
+        spsaData.param_names.length >= 1000
           ? "Too many tuning parameters to generate plot."
           : "Not enough data to generate plot.",
       );
@@ -491,7 +455,7 @@ async function handleSPSA() {
 
     if (
       lastSelectedParam != null &&
-      lastSelectedParam > spsaData.params.length
+      lastSelectedParam > spsaData.param_names.length
     ) {
       lastSelectedParam = null;
       viewAll = true;

--- a/server/fishtest/templates/tests_run.html.j2
+++ b/server/fishtest/templates/tests_run.html.j2
@@ -349,8 +349,8 @@
               <input
                 type="number"
                 name="num-games"
-                min="1000"
-                step="1000"
+                min="{{ create_num_games_constraints.min }}"
+                step="{{ create_num_games_constraints.step }}"
                 id="num-games"
                 class="form-control"
                 value="{{ args.get("num_games", 60000) }}"
@@ -406,8 +406,10 @@
             {# This only appears when spsa is selected #}
             <div
               class="mb-2 stop-rule stop-rule-spsa"
-              style="{{ args.get("spsa") or "display: none" }}"
+              style="{{ '' if args.get("spsa") else 'display: none' }}"
             >
+              <input type="hidden" name="spsa_algorithm" id="spsa_algorithm" value="{{ spsa_form["algorithm"] }}">
+
               <div class="row gx-1">
                 <div class="col-4">
                   <div class="mb-2">
@@ -420,7 +422,7 @@
                       name="spsa_A"
                       id="spsa_A"
                       class="form-control"
-                      value="{{ args.get("spsa", {"A": "0.1"})["A"] }}"
+                      value="{{ spsa_form["A"] }}"
                     >
                   </div>
                 </div>
@@ -434,7 +436,7 @@
                       name="spsa_alpha"
                       id="spsa_alpha"
                       class="form-control"
-                      value="{{ args.get("spsa", {"alpha": "0.602"})["alpha"] }}"
+                      value="{{ spsa_form["alpha"] }}"
                     >
                   </div>
                 </div>
@@ -448,7 +450,7 @@
                       name="spsa_gamma"
                       id="spsa_gamma"
                       class="form-control"
-                      value="{{ args.get("spsa", {"gamma": "0.101"})["gamma"] }}"
+                      value="{{ spsa_form["gamma"] }}"
                     >
                   </div>
                 </div>
@@ -461,7 +463,7 @@
                   id="spsa_raw_params"
                   class="form-control"
                   placeholder="Paste values printed at the startup of the code here"
-                >{{ args.get("spsa", {"raw_params": ""})["raw_params"] }}</textarea>
+                >{{ spsa_form["raw_params"] }}</textarea>
               </div>
 
               <div class="mb-2 form-check">
@@ -1157,7 +1159,12 @@
     document.getElementById("spsa_A").value = 0;
     document.getElementById("spsa_alpha").value = 0.0;
     document.getElementById("spsa_gamma").value = 0.0;
-    document.getElementById("num-games").value = 1000 * Math.round(s.num_games / 1000);
+    const numGamesMin = {{ create_num_games_constraints.min }};
+    const numGamesStep = {{ create_num_games_constraints.step }};
+    document.getElementById("num-games").value = Math.max(
+      numGamesMin,
+      numGamesStep * Math.round(s.num_games / numGamesStep),
+    );
     document.getElementById("spsa_raw_params").value = fs.trim();
     return true;
   }

--- a/server/fishtest/templates/tests_view.html.j2
+++ b/server/fishtest/templates/tests_view.html.j2
@@ -219,8 +219,8 @@
               class="form-control"
               name="num-games"
               id="modify-num-games"
-              min="0"
-              step="1000"
+              min="{{ modify_num_games_constraints.min }}"
+              step="{{ modify_num_games_constraints.step }}"
               value="{{ run["args"]["num_games"] }}"
             >
           </div>

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -14,7 +14,7 @@ import hashlib
 import logging
 import os
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, TypedDict
@@ -115,6 +115,7 @@ from fishtest.schemas import (
     runs_schema,
     short_worker_name,
 )
+from fishtest.spsa_workflow import build_spsa_form_values, format_spsa_value
 from fishtest.util import (
     VALID_USERNAME_PATTERN,
     email_valid,
@@ -161,6 +162,8 @@ from fishtest.views_machines import (
 )
 from fishtest.views_machines import tests_machines as _tests_machines_impl
 from fishtest.views_run import (
+    CREATE_FORM_NUM_GAMES_CONSTRAINTS,
+    MODIFY_FORM_NUM_GAMES_CONSTRAINTS,
     can_modify_run,
     del_tasks,
     get_master_info,
@@ -168,7 +171,6 @@ from fishtest.views_run import (
     get_sha,  # noqa: F401 — re-exported for test_github_api.py
     is_same_user,
     new_run_message,
-    parse_spsa_params,  # noqa: F401 — re-exported for test compatibility
     sanitize_options,
     update_nets,
     validate_form,
@@ -399,6 +401,14 @@ class _ViewContext:
     individual handlers can stay synchronous and focused on shaping template
     context.
     """
+
+    raw_request: Request
+    session: CookieSession
+    cookies: Mapping[str, Any]
+    response_headerlist: list[tuple[str, str]]
+    remember: bool
+    forget: bool
+    remember_max_age: int | None
 
     def __init__(
         self,
@@ -2419,11 +2429,11 @@ def tests_run(request: _ViewContext) -> dict[str, Any] | RedirectResponse:
         if run is None:
             raise StarletteHTTPException(status_code=404)
         run_args = copy.deepcopy(run["args"])
-        if "spsa" in run_args:
-            # needs deepcopy
-            run_args["spsa"]["A"] = (
-                round(1000 * 2 * run_args["spsa"]["A"] / run_args["num_games"]) / 1000
-            )
+
+    spsa_form = build_spsa_form_values(
+        run_args.get("spsa"),
+        num_games=run_args.get("num_games"),
+    )
 
     username = request.authenticated_userid
     u = request.userdb.get_user(username)
@@ -2456,12 +2466,14 @@ def tests_run(request: _ViewContext) -> dict[str, Any] | RedirectResponse:
         "new_options_value": new_options_value,
         "base_options_value": base_options_value,
         "info_value": info_value,
+        "spsa_form": spsa_form,
         "test_book": test_book,
         "pt_book": pt_book,
         "master_info": master_info,
         "valid_books": request.rundb.books.keys(),
         "pt_info": request.rundb.pt_info,
         "setup": setup,
+        "create_num_games_constraints": CREATE_FORM_NUM_GAMES_CONSTRAINTS,
         "supported_arches": supported_arches,
         "supported_compilers": supported_compilers,
     }
@@ -3188,50 +3200,6 @@ def _set_tasks_cookies(
     )
 
 
-def _format_tests_view_spsa_value(
-    run: dict[str, Any],
-    value: dict[str, Any],
-) -> list[str | _SpsaTableRow]:
-    iter_local = value["iter"] + 1  # start from 1 to avoid division by zero
-    A = value["A"]  # noqa: N806
-    alpha = value["alpha"]
-    gamma = value["gamma"]
-    summary = (
-        f"iter: {iter_local:d}, A: {A:d}, alpha: {alpha:0.3f}, gamma: {gamma:0.3f}"
-    )
-    params = value["params"]
-    spsa_value: list[str | _SpsaTableRow] = [summary]
-    for p in params:
-        try:
-            c_iter = p["c"] / (iter_local**gamma)
-            r_iter = p["a"] / (A + iter_local) ** alpha / c_iter**2
-        except (ArithmeticError, TypeError, ValueError) as e:
-            logger.warning(
-                "Invalid SPSA param state while rendering "
-                "run %s (iter=%d, param=%s): %s",
-                run["_id"],
-                iter_local,
-                p.get("name", "<unknown>"),
-                e,
-            )
-            c_iter = float("nan")
-            r_iter = float("nan")
-        spsa_value.append(
-            [
-                p["name"],
-                "{:.2f}".format(p["theta"]),
-                str(int(p["start"])),
-                str(int(p["min"])),
-                str(int(p["max"])),
-                f"{c_iter:.3f}",
-                "{:.3f}".format(p["c_end"]),
-                f"{r_iter:.2e}",
-                "{:.2e}".format(p["r_end"]),
-            ],
-        )
-    return spsa_value
-
-
 def _format_tests_view_string_arg(
     run: dict[str, Any],
     name: str,
@@ -3277,7 +3245,11 @@ def _format_tests_view_dict_arg(
             value.get("elo_model", "BayesElo"),
         )
     if name == "spsa":
-        return _format_tests_view_spsa_value(run, value)
+        return format_spsa_value(
+            value,
+            logger=logger,
+            run_id=str(run["_id"]),
+        )
     return str(value)
 
 
@@ -3716,6 +3688,7 @@ def tests_view(request: _ViewContext) -> dict[str, Any] | RedirectResponse:  # n
         "tasks_is_truncated": tasks_table_context["is_truncated"],
         "follow": follow,
         "can_modify_run": can_modify_run(request, run),
+        "modify_num_games_constraints": MODIFY_FORM_NUM_GAMES_CONSTRAINTS,
         "same_user": same_user,
         "pt_info": request.rundb.pt_info,
         "notes": notes,

--- a/server/fishtest/views_machines.py
+++ b/server/fishtest/views_machines.py
@@ -7,7 +7,10 @@ support the ``tests_machines`` entry point.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 from fishtest.http.settings import (
     MACHINES_PAGE_SIZE,
@@ -132,7 +135,7 @@ def _normalize_machine_row(machine: dict[str, Any]) -> dict[str, Any]:
 
 
 def _machine_filter_state(
-    query_source: dict[str, Any],
+    query_source: Mapping[str, Any],
     *,
     authenticated_username: str | None,
     use_cookies: bool = False,

--- a/server/fishtest/views_run.py
+++ b/server/fishtest/views_run.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import copy
 import logging
 import re
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -16,6 +17,7 @@ import regex
 
 import fishtest.github_api as gh
 import fishtest.stats.stat_util
+from fishtest.spsa_workflow import build_spsa_state
 from fishtest.util import (
     format_bounds,
     get_hash,
@@ -27,8 +29,19 @@ from fishtest.views_helpers import _host_url
 
 logger = logging.getLogger(__name__)
 
-_SPSA_PARAM_FIELDS = 6
 _RUN_MODIFY_MAX_AGE_DAYS = 30
+
+
+@dataclass(frozen=True)
+class NumGamesConstraints:
+    """Shared browser-and-server constraints for num-games inputs."""
+
+    min: int
+    step: int
+
+
+CREATE_FORM_NUM_GAMES_CONSTRAINTS = NumGamesConstraints(min=1000, step=1000)
+MODIFY_FORM_NUM_GAMES_CONSTRAINTS = NumGamesConstraints(min=0, step=1000)
 
 if TYPE_CHECKING:
     from starlette.responses import RedirectResponse
@@ -172,44 +185,19 @@ def get_nets(commit_sha: str, repo_url: str) -> list[str]:  # noqa: C901
         return nets
 
 
-def parse_spsa_params(spsa: dict[str, Any]) -> list[dict[str, Any]]:
-    """Parse raw SPSA parameter strings into structured dicts."""
-    raw = spsa["raw_params"]
-    params = []
-    for line in raw.split("\n"):
-        chunks = line.strip().split(",")
-        if len(chunks) == 1 and chunks[0] == "":  # blank line
-            continue
-        if len(chunks) != _SPSA_PARAM_FIELDS:
-            msg = f"the line {chunks} does not have {_SPSA_PARAM_FIELDS} entries"
-            raise ValueError(msg)
-        param = {
-            "name": chunks[0],
-            "start": float(chunks[1]),
-            "min": float(chunks[2]),
-            "max": float(chunks[3]),
-            "c_end": float(chunks[4]),
-            "r_end": float(chunks[5]),
-        }
-        param["c"] = param["c_end"] * spsa["num_iter"] ** spsa["gamma"]
-        param["a_end"] = param["r_end"] * param["c_end"] ** 2
-        param["a"] = param["a_end"] * (spsa["A"] + spsa["num_iter"]) ** spsa["alpha"]
-        param["theta"] = param["start"]
-        params.append(param)
-    return params
-
-
 def validate_modify(  # noqa: PLR0911
     request: Any,  # noqa: ANN401
     run: dict[str, Any],
+    *,
+    now: datetime | None = None,
 ) -> RedirectResponse | None:
     """Return None on success, or a RedirectResponse on validation failure."""
     from starlette.responses import RedirectResponse  # noqa: PLC0415
 
-    now = datetime.now(UTC)
+    current_time = datetime.now(UTC) if now is None else now
     if (
         "start_time" not in run
-        or (now - run["start_time"]).days > _RUN_MODIFY_MAX_AGE_DAYS
+        or (current_time - run["start_time"]).days > _RUN_MODIFY_MAX_AGE_DAYS
     ):
         request.session.flash("Run too old to be modified", "error")
         return RedirectResponse(url="/tests", status_code=302)
@@ -252,6 +240,15 @@ def validate_modify(  # noqa: PLR0911
         )
         return RedirectResponse(url="/tests", status_code=302)
 
+    try:
+        _validate_num_games_value(
+            num_games,
+            constraints=MODIFY_FORM_NUM_GAMES_CONSTRAINTS,
+        )
+    except ValueError as error:
+        request.session.flash(str(error), "error")
+        return RedirectResponse(url="/tests", status_code=302)
+
     max_games = 3200000
     if num_games > max_games:
         request.session.flash("Number of games must be <= " + str(max_games), "error")
@@ -279,6 +276,20 @@ def sanitize_options(options: str) -> str:
             )
             raise ValueError(msg)
     return " ".join(tokens)
+
+
+def _validate_num_games_value(
+    num_games: int,
+    *,
+    constraints: NumGamesConstraints,
+) -> int:
+    if num_games < constraints.min:
+        msg = f"Number of games must be >= {constraints.min}"
+        raise ValueError(msg)
+    if num_games % constraints.step != 0:
+        msg = f"Number of games must be a multiple of {constraints.step}"
+        raise ValueError(msg)
+    return num_games
 
 
 def validate_form(request: Any) -> dict[str, Any]:  # noqa: ANN401, C901, PLR0912, PLR0915
@@ -555,28 +566,23 @@ def validate_form(request: Any) -> dict[str, Any]:  # noqa: ANN401, C901, PLR091
         # Limit on number of games played.
         data["num_games"] = 800000
     elif stop_rule == "spsa":
-        data["num_games"] = int(request.POST["num-games"])
-        if data["num_games"] <= 0:
-            msg = "Number of games must be >= 0"
-            raise ValueError(msg)
+        data["num_games"] = _validate_num_games_value(
+            int(request.POST["num-games"]),
+            constraints=CREATE_FORM_NUM_GAMES_CONSTRAINTS,
+        )
 
-        data["spsa"] = {
-            "A": int(float(request.POST["spsa_A"]) * data["num_games"] / 2),
-            "alpha": float(request.POST["spsa_alpha"]),
-            "gamma": float(request.POST["spsa_gamma"]),
-            "raw_params": request.POST["spsa_raw_params"],
-            "iter": 0,
-            "num_iter": int(data["num_games"] / 2),
-        }
-        data["spsa"]["params"] = parse_spsa_params(data["spsa"])
+        data["spsa"] = build_spsa_state(
+            request.POST,
+            num_games=data["num_games"],
+        )
         if len(data["spsa"]["params"]) == 0:
             msg = "Number of params must be > 0"
             raise ValueError(msg)
     else:
-        data["num_games"] = int(request.POST["num-games"])
-        if data["num_games"] <= 0:
-            msg = "Number of games must be >= 0"
-            raise ValueError(msg)
+        data["num_games"] = _validate_num_games_value(
+            int(request.POST["num-games"]),
+            constraints=CREATE_FORM_NUM_GAMES_CONSTRAINTS,
+        )
 
     max_games = 3200000
     if data["num_games"] > max_games:

--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -156,7 +156,7 @@ class CreateRunDBTest(unittest.TestCase):
         run = self.rundb.get_run(run_id)
         run["args"]["spsa"] = {
             "iter": 7,
-            "param_history": [[{"theta": 12.0, "c": 1.5}]],
+            "param_history": [[{"theta": 12.0, "R": 0.08, "c": 1.5}]],
         }
         run["bad_tasks"] = [
             {"num_games": 0, "stats": {"wins": 0, "draws": 0, "losses": 0}}

--- a/server/tests/test_spsa_workflow.py
+++ b/server/tests/test_spsa_workflow.py
@@ -1,0 +1,393 @@
+"""Test the shared SPSA lifecycle helper contracts."""
+
+import json
+import unittest
+from math import isfinite
+
+from fishtest.spsa_workflow import (
+    CLASSIC_SPSA_ALGORITHM,
+    apply_spsa_result_updates,
+    build_spsa_chart_payload,
+    build_spsa_form_values,
+    build_spsa_state,
+    build_spsa_worker_step,
+)
+
+
+class SpsaWorkflowTests(unittest.TestCase):
+    def test_build_spsa_form_values_defaults_to_classic(self):
+        values = build_spsa_form_values(None)
+
+        self.assertEqual(values["algorithm"], CLASSIC_SPSA_ALGORITHM)
+        self.assertEqual(values["A"], 0.1)
+        self.assertEqual(values["alpha"], 0.602)
+        self.assertEqual(values["gamma"], 0.101)
+        self.assertEqual(values["raw_params"], "")
+
+    def test_build_spsa_form_values_uses_ratio_without_mutating_state(self):
+        spsa = {
+            "algorithm": CLASSIC_SPSA_ALGORITHM,
+            "A": 25,
+            "alpha": 0.602,
+            "gamma": 0.101,
+            "raw_params": "Tempo,1,0,2,0.5,0.1",
+        }
+
+        values = build_spsa_form_values(spsa, num_games=500)
+
+        self.assertEqual(values["A"], 0.1)
+        self.assertEqual(spsa["A"], 25)
+
+    def test_build_spsa_state_sets_classic_algorithm_and_params(self):
+        post = {
+            "spsa_algorithm": CLASSIC_SPSA_ALGORITHM,
+            "spsa_A": "0.1",
+            "spsa_alpha": "0.602",
+            "spsa_gamma": "0.101",
+            "spsa_raw_params": "Tempo,1,0,2,0.5,0.1",
+        }
+
+        spsa = build_spsa_state(post, num_games=500)
+
+        self.assertEqual(spsa["algorithm"], CLASSIC_SPSA_ALGORITHM)
+        self.assertEqual(spsa["A"], 25)
+        self.assertEqual(spsa["num_iter"], 250)
+        self.assertEqual(spsa["params"][0]["theta"], 1.0)
+
+    def test_build_spsa_state_rejects_unknown_algorithm(self):
+        post = {
+            "spsa_algorithm": "unknown",
+            "spsa_A": "0.1",
+            "spsa_alpha": "0.602",
+            "spsa_gamma": "0.101",
+            "spsa_raw_params": "Tempo,1,0,2,0.5,0.1",
+        }
+
+        with self.assertRaisesRegex(ValueError, "Unknown SPSA algorithm"):
+            build_spsa_state(post, num_games=500)
+
+    def test_build_spsa_state_rejects_invalid_hyperparameters(self):
+        base_post = {
+            "spsa_algorithm": CLASSIC_SPSA_ALGORITHM,
+            "spsa_A": "0.1",
+            "spsa_alpha": "0.602",
+            "spsa_gamma": "0.101",
+            "spsa_raw_params": "Tempo,1,0,2,0.5,0.1",
+        }
+
+        invalid_cases = [
+            ("spsa_A", "nan", "A ratio"),
+            ("spsa_alpha", "inf", "alpha"),
+            ("spsa_gamma", "-1", ">= 0"),
+        ]
+
+        for field_name, raw_value, pattern in invalid_cases:
+            post = dict(base_post)
+            post[field_name] = raw_value
+
+            with self.subTest(field_name=field_name, raw_value=raw_value):
+                with self.assertRaisesRegex(ValueError, pattern):
+                    build_spsa_state(post, num_games=500)
+
+    def test_build_spsa_worker_step_uses_classic_decay(self):
+        spsa = {
+            "algorithm": CLASSIC_SPSA_ALGORITHM,
+            "A": 25,
+            "alpha": 0.602,
+            "gamma": 0.101,
+        }
+        param = {"a": 0.2, "c": 1.6}
+
+        worker_step = build_spsa_worker_step(spsa, param, iter_value=2, flip=1)
+
+        expected_c = 1.6 / (3**0.101)
+        expected_R = 0.2 / (28**0.602) / expected_c**2
+        self.assertAlmostEqual(worker_step["c"], expected_c)
+        self.assertAlmostEqual(worker_step["R"], expected_R)
+        self.assertEqual(worker_step["flip"], 1)
+
+    def test_apply_spsa_result_updates_preserves_classic_update_rule(self):
+        spsa = {
+            "algorithm": CLASSIC_SPSA_ALGORITHM,
+            "iter": 4,
+            "params": [
+                {
+                    "theta": 10.0,
+                    "min": 0.0,
+                    "max": 20.0,
+                },
+            ],
+        }
+        w_params = [{"R": 0.5, "c": 2.0, "flip": 1}]
+
+        result = apply_spsa_result_updates(
+            spsa,
+            w_params,
+            result=3,
+            game_pairs=10,
+        )
+
+        self.assertIsNone(result)
+        self.assertEqual(spsa["params"][0]["theta"], 13.0)
+
+    def test_apply_spsa_result_updates_rejects_length_mismatch(self):
+        spsa = {
+            "algorithm": CLASSIC_SPSA_ALGORITHM,
+            "iter": 4,
+            "params": [
+                {
+                    "theta": 10.0,
+                    "min": 0.0,
+                    "max": 20.0,
+                },
+                {
+                    "theta": 11.0,
+                    "min": 0.0,
+                    "max": 20.0,
+                },
+            ],
+        }
+
+        with self.assertRaisesRegex(ValueError, "length mismatch"):
+            apply_spsa_result_updates(
+                spsa,
+                [{"R": 0.5, "c": 2.0, "flip": 1}],
+                result=3,
+                game_pairs=10,
+            )
+
+    def test_build_spsa_chart_payload_returns_server_shaped_chart_rows(self):
+        spsa = {
+            "iter": 2,
+            "num_iter": 10,
+            "A": 4,
+            "alpha": 0.602,
+            "gamma": 0.101,
+            "params": [
+                {
+                    "name": "ParamA",
+                    "theta": 12.5,
+                    "start": 10,
+                    "min": 0,
+                    "max": 20,
+                    "c": 1.6,
+                    "c_end": 0.1,
+                    "a": 0.2,
+                    "r_end": 1.0e-03,
+                },
+            ],
+            "param_history": [[{"theta": 12.0, "R": 0.08, "c": 1.5}]],
+        }
+
+        payload = build_spsa_chart_payload(spsa)
+
+        self.assertEqual(
+            set(payload),
+            {
+                "param_names",
+                "chart_rows",
+            },
+        )
+        self.assertEqual(payload["param_names"], ["ParamA"])
+        self.assertEqual(
+            payload["chart_rows"][0],
+            {"iter_ratio": 0.0, "values": [10.0]},
+        )
+        self.assertEqual(payload["chart_rows"][1]["values"], [12.0])
+        self.assertEqual(payload["chart_rows"][1]["c_values"], [1.5])
+        self.assertEqual(payload["chart_rows"][2]["values"], [12.5])
+        self.assertGreater(
+            payload["chart_rows"][2]["iter_ratio"],
+            payload["chart_rows"][1]["iter_ratio"],
+        )
+        self.assertAlmostEqual(
+            payload["chart_rows"][2]["c_values"][0],
+            1.6 / (3**0.101),
+        )
+
+    def test_build_spsa_chart_payload_deduplicates_matching_live_row(self):
+        live_c = 1.6 / (21**0.101)
+        spsa = {
+            "iter": 20,
+            "num_iter": 250,
+            "A": 4,
+            "alpha": 0.602,
+            "gamma": 0.101,
+            "params": [
+                {
+                    "name": "ParamA",
+                    "theta": 12.5,
+                    "start": 10,
+                    "min": 0,
+                    "max": 20,
+                    "c": 1.6,
+                    "c_end": 0.1,
+                    "a": 0.2,
+                    "r_end": 1.0e-03,
+                },
+            ],
+            "param_history": [[{"theta": 12.5, "R": 0.08, "c": live_c}]],
+        }
+
+        payload = build_spsa_chart_payload(spsa)
+
+        self.assertEqual(len(payload["chart_rows"]), 2)
+        self.assertAlmostEqual(payload["chart_rows"][-1]["iter_ratio"], 20 / 250)
+        self.assertEqual(payload["chart_rows"][-1]["values"], [12.5])
+        self.assertEqual(payload["chart_rows"][-1]["c_values"], [live_c])
+
+    def test_build_spsa_chart_payload_recovers_sample_iters_from_c_values(self):
+        gamma = 0.101
+        base_c = 1.6
+        sample_iter_1 = 20
+        sample_iter_2 = 200
+        spsa = {
+            "iter": 201,
+            "num_iter": 250,
+            "A": 4,
+            "alpha": 0.602,
+            "gamma": gamma,
+            "params": [
+                {
+                    "name": "ParamA",
+                    "theta": 12.5,
+                    "start": 10,
+                    "min": 0,
+                    "max": 20,
+                    "c": base_c,
+                    "c_end": 0.1,
+                    "a": 0.2,
+                    "r_end": 1.0e-03,
+                },
+            ],
+            "param_history": [
+                [
+                    {
+                        "theta": 11.5,
+                        "R": 0.08,
+                        "c": base_c / ((sample_iter_1 + 1) ** gamma),
+                    }
+                ],
+                [
+                    {
+                        "theta": 12.0,
+                        "R": 0.08,
+                        "c": base_c / ((sample_iter_2 + 1) ** gamma),
+                    }
+                ],
+            ],
+        }
+
+        payload = build_spsa_chart_payload(spsa)
+
+        self.assertEqual(len(payload["chart_rows"]), 4)
+        self.assertAlmostEqual(
+            payload["chart_rows"][1]["iter_ratio"],
+            sample_iter_1 / 250,
+        )
+        self.assertAlmostEqual(
+            payload["chart_rows"][2]["iter_ratio"],
+            sample_iter_2 / 250,
+        )
+        self.assertAlmostEqual(
+            payload["chart_rows"][3]["iter_ratio"],
+            201 / 250,
+        )
+        self.assertEqual(payload["chart_rows"][3]["values"], [12.5])
+
+    def test_build_spsa_chart_payload_falls_back_to_master_spacing_without_c(self):
+        spsa = {
+            "iter": 20,
+            "num_iter": 250,
+            "A": 4,
+            "alpha": 0.602,
+            "gamma": 0.101,
+            "params": [
+                {
+                    "name": "ParamA",
+                    "theta": 12.5,
+                    "start": 10,
+                    "min": 0,
+                    "max": 20,
+                    "c": 1.6,
+                    "c_end": 0.1,
+                    "a": 0.2,
+                    "r_end": 1.0e-03,
+                },
+            ],
+            "param_history": [
+                [{"theta": 11.0, "R": 0.08}],
+                [{"theta": 12.0, "R": 0.08}],
+            ],
+        }
+
+        payload = build_spsa_chart_payload(spsa)
+
+        self.assertEqual(len(payload["chart_rows"]), 4)
+        self.assertAlmostEqual(payload["chart_rows"][1]["iter_ratio"], 20 / 250 / 3)
+        self.assertAlmostEqual(payload["chart_rows"][2]["iter_ratio"], 2 * 20 / 250 / 3)
+        self.assertAlmostEqual(payload["chart_rows"][3]["iter_ratio"], 20 / 250)
+
+    def test_build_spsa_chart_payload_ignores_non_list_history_samples(self):
+        spsa = {
+            "iter": 20,
+            "num_iter": 250,
+            "A": 4,
+            "alpha": 0.602,
+            "gamma": 0.101,
+            "params": [
+                {
+                    "name": "ParamA",
+                    "theta": 12.5,
+                    "start": 10,
+                    "min": 0,
+                    "max": 20,
+                    "c": 1.6,
+                    "c_end": 0.1,
+                    "a": 0.2,
+                    "r_end": 1.0e-03,
+                },
+            ],
+            "param_history": [
+                {"iter": 2, "params": [{"theta": 12.0, "R": 0.08, "c": 1.5}]}
+            ],
+        }
+
+        payload = build_spsa_chart_payload(spsa)
+
+        self.assertEqual(
+            payload["chart_rows"],
+            [{"iter_ratio": 0.0, "values": [10.0]}],
+        )
+
+    def test_build_spsa_chart_payload_sanitizes_non_finite_numbers(self):
+        spsa = {
+            "iter": float("inf"),
+            "num_iter": 10,
+            "gamma": float("nan"),
+            "params": [
+                {
+                    "name": "ParamA",
+                    "theta": float("inf"),
+                    "start": float("nan"),
+                    "c": float("inf"),
+                },
+            ],
+            "param_history": [[{"theta": float("nan"), "R": 0.08, "c": float("inf")}]],
+        }
+
+        payload = build_spsa_chart_payload(spsa)
+        serialized = json.dumps(payload)
+
+        self.assertNotIn("Infinity", serialized)
+        self.assertNotIn("NaN", serialized)
+        for row in payload["chart_rows"]:
+            self.assertTrue(isfinite(row["iter_ratio"]))
+            for value in row["values"]:
+                self.assertTrue(isfinite(value))
+            for c_value in row.get("c_values", []):
+                self.assertTrue(c_value is None or isfinite(c_value))
+
+    def test_build_spsa_chart_payload_rejects_unknown_algorithm(self):
+        with self.assertRaisesRegex(ValueError, "Unknown SPSA algorithm"):
+            build_spsa_chart_payload({"algorithm": "unknown"})

--- a/server/tests/test_views_detail.py
+++ b/server/tests/test_views_detail.py
@@ -143,7 +143,7 @@ class TestTestsViewDetail(unittest.TestCase):
                     "r_end": 1.0e-03,
                 },
             ],
-            "param_history": [[{"theta": 12.0, "c": 1.5}]],
+            "param_history": [[{"theta": 12.0, "R": 0.08, "c": 1.5}]],
         }
         self.rundb.buffer(run, priority=Prio.SAVE_NOW)
         return run_id
@@ -175,6 +175,8 @@ class TestTestsViewDetail(unittest.TestCase):
             f'id="spsa-data-{run_id}" type="application/json"',
             response.text,
         )
+        self.assertIn('"param_names"', response.text)
+        self.assertIn('"chart_rows"', response.text)
         self.assertIn('id="spsa_history_scroll"', response.text)
         self.assertIn('id="spsa_history_plot"', response.text)
         self.assertRegex(
@@ -427,8 +429,8 @@ class TestTestsViewDetail(unittest.TestCase):
                 },
             ],
             "param_history": [
-                [{"theta": 11.5, "c": 1.5}],
-                [{"theta": 12.0, "c": 1.4}],
+                [{"theta": 11.5, "R": 0.09, "c": 1.5}],
+                [{"theta": 12.0, "R": 0.08, "c": 1.4}],
             ],
         }
         self.rundb.buffer(run, priority=Prio.SAVE_NOW)
@@ -458,26 +460,14 @@ class TestTestsViewDetail(unittest.TestCase):
             f'id="spsa-data-{run_id}" type="application/json" hx-swap-oob="innerHTML"',
             response.text,
         )
+        self.assertIn('"param_names"', response.text)
+        self.assertIn('"chart_rows"', response.text)
         self.assertIn("ParamA", response.text)
         self.assertIn("iter: 3, A: 4", response.text)
         self.assertNotIn("<title>", response.text)
 
-    def test_spsa_script_skips_noop_redraws_without_hover_gating(self):
-        script_path = (
-            Path(__file__).resolve().parents[1]
-            / "fishtest"
-            / "static"
-            / "js"
-            / "spsa.js"
-        )
-        script_source = script_path.read_text(encoding="utf-8")
 
-        self.assertIn("payloadText === lastRenderedPayloadText", script_source)
-        self.assertIn("const scroller = getSPSAScrollContainer();", script_source)
-        self.assertNotIn('historyPlot.addEventListener("pointerenter"', script_source)
-        self.assertNotIn('historyPlot.addEventListener("pointerleave"', script_source)
-        self.assertNotIn("deferredRefreshPending", script_source)
-
+class TestSpsaChartAssets(unittest.TestCase):
     def test_spsa_plot_shell_keeps_fixed_chart_dimensions(self):
         repo_root = Path(__file__).resolve().parents[1]
         template_source = (
@@ -507,6 +497,63 @@ class TestTestsViewDetail(unittest.TestCase):
         self.assertNotIn("chartOptions.width = plotSize.width", script_source)
         self.assertIn("width: 1000,", script_source)
         self.assertIn("height: 500,", script_source)
+
+    def test_spsa_plot_script_reads_server_shaped_chart_rows(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        script_source = (
+            repo_root / "fishtest" / "static" / "js" / "spsa.js"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "if (spsaData.chart_rows.length <= 1) {",
+            script_source,
+        )
+        self.assertIn(
+            "Array.isArray(nextData.chart_rows)",
+            script_source,
+        )
+        self.assertIn(
+            "const chartRows = spsaData.chart_rows;",
+            script_source,
+        )
+        self.assertIn(
+            "dt0.addRows(",
+            script_source,
+        )
+        self.assertNotIn("getLastHistorySample", script_source)
+        self.assertNotIn("shouldPlotLivePoint", script_source)
+        self.assertNotIn("sampleMatchesLive", script_source)
+        self.assertNotIn("reconcileHistoryPointIters", script_source)
+        self.assertNotIn("plot_live", script_source)
+        self.assertNotIn("param_history", script_source)
+
+    def test_spsa_percentage_uses_server_shaped_c_values(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        script_source = (
+            repo_root / "fishtest" / "static" / "js" / "spsa.js"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "const cValue = Number(chartRows[row]?.c_values?.[i]);",
+            script_source,
+        )
+        self.assertIn(
+            "return (dt.getValue(row, i + 1) - dt.getValue(0, i + 1)) / cValue;",
+            script_source,
+        )
+        self.assertNotIn(
+            "const gamma = asFiniteNumber(spsaData.gamma, 0);",
+            script_source,
+        )
+        self.assertNotIn(
+            "Math.pow(iterValue + 1, gamma)",
+            script_source,
+        )
+        self.assertNotIn(
+            "plotLive",
+            script_source,
+        )
+        self.assertNotIn("sample.params", script_source)
 
 
 class TestTestsViewTasks(UiUserTestCase):

--- a/server/tests/test_views_run.py
+++ b/server/tests/test_views_run.py
@@ -2,6 +2,7 @@
 
 import unittest
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest import mock
 
 import test_support
@@ -9,12 +10,12 @@ from starlette.responses import RedirectResponse
 from ui_user_test_case import UiUserTestCase
 
 from fishtest.run_cache import Prio
+from fishtest.spsa_workflow import parse_spsa_params
 from fishtest.views_run import (
     _RUN_MODIFY_MAX_AGE_DAYS,
     can_modify_run,
     del_tasks,
     is_same_user,
-    parse_spsa_params,
     sanitize_options,
     validate_form,
     validate_modify,
@@ -24,7 +25,7 @@ BASE_TIME = datetime(2026, 3, 17, tzinfo=UTC)
 BASE_THREADS = "1"
 BASE_PRIORITY = "10"
 BASE_THROUGHPUT = "100"
-BASE_NUM_GAMES = "200"
+BASE_NUM_GAMES = "1000"
 BASE_TC = "10+0.1"
 BASE_REPO = "https://github.com/official-stockfish/Stockfish"
 BASE_SIGNATURE = "123456"
@@ -142,6 +143,30 @@ class SpsaParsingTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, str(SPSA_FIELD_COUNT)):
             parse_spsa_params(spsa)
 
+    def test_parse_spsa_params_rejects_non_finite_values(self):
+        spsa = {
+            "raw_params": "Tempo,nan,0,2,0.5,0.1",
+            "num_iter": 100,
+            "gamma": 0.101,
+            "A": 25,
+            "alpha": 0.602,
+        }
+
+        with self.assertRaisesRegex(ValueError, "line 1 field start"):
+            parse_spsa_params(spsa)
+
+    def test_parse_spsa_params_rejects_non_positive_c_end(self):
+        spsa = {
+            "raw_params": "Tempo,1,0,2,0,0.1",
+            "num_iter": 100,
+            "gamma": 0.101,
+            "A": 25,
+            "alpha": 0.602,
+        }
+
+        with self.assertRaisesRegex(ValueError, "line 1 field c_end"):
+            parse_spsa_params(spsa)
+
 
 class SanitizeOptionsTests(unittest.TestCase):
     def test_sanitize_options_normalizes_spacing(self):
@@ -159,10 +184,10 @@ class ValidateModifyTests(unittest.TestCase):
         request = _RequestStub(post_data=_valid_post_data())
         old_run = {
             "start_time": BASE_TIME - timedelta(days=_RUN_MODIFY_MAX_AGE_DAYS + 1),
-            "args": {"num_games": 200},
+            "args": {"num_games": 1000},
         }
 
-        response = validate_modify(request, old_run)
+        response = validate_modify(request, old_run, now=BASE_TIME)
 
         self.assertIsInstance(response, RedirectResponse)
         self.assertEqual(request.session.messages[0][1], "error")
@@ -171,12 +196,42 @@ class ValidateModifyTests(unittest.TestCase):
         request = _RequestStub(post_data=_valid_post_data())
         current_run = {
             "start_time": BASE_TIME,
-            "args": {"num_games": 400},
+            "args": {"num_games": 1000},
         }
 
-        response = validate_modify(request, current_run)
+        response = validate_modify(request, current_run, now=BASE_TIME)
 
         self.assertIsNone(response)
+
+    def test_validate_modify_allows_zero_games(self):
+        post_data = _valid_post_data()
+        post_data["num-games"] = "0"
+        request = _RequestStub(post_data=post_data)
+        current_run = {
+            "start_time": BASE_TIME,
+            "args": {"num_games": 1000},
+        }
+
+        response = validate_modify(request, current_run, now=BASE_TIME)
+
+        self.assertIsNone(response)
+
+    def test_validate_modify_rejects_non_thousand_step_games(self):
+        post_data = _valid_post_data()
+        post_data["num-games"] = "1500"
+        request = _RequestStub(post_data=post_data)
+        current_run = {
+            "start_time": BASE_TIME,
+            "args": {"num_games": 2000},
+        }
+
+        response = validate_modify(request, current_run, now=BASE_TIME)
+
+        self.assertIsInstance(response, RedirectResponse)
+        self.assertEqual(
+            request.session.messages,
+            [("Number of games must be a multiple of 1000", "error")],
+        )
 
 
 class ValidateFormTests(unittest.TestCase):
@@ -206,6 +261,83 @@ class ValidateFormTests(unittest.TestCase):
         self.assertNotIn("arch_filter", data)
         self.assertEqual(data["resolved_base"], BASE_SHA)
         self.assertEqual(data["resolved_new"], NEW_SHA)
+
+    def test_validate_form_numgames_path_rejects_one_game_with_correct_message(self):
+        post_data = _valid_post_data()
+        post_data["num-games"] = "1"
+        request = _RequestStub(post_data=post_data)
+
+        with (
+            mock.patch(
+                "fishtest.views_run.gh.normalize_repo", side_effect=lambda repo: repo
+            ),
+            mock.patch(
+                "fishtest.views_run.gh.parse_repo",
+                return_value=("official-stockfish", "Stockfish"),
+            ),
+            mock.patch("fishtest.views_run.gh.get_master_repo", return_value=BASE_REPO),
+            mock.patch(
+                "fishtest.views_run.get_sha",
+                side_effect=[(BASE_SHA, "base"), (NEW_SHA, "new")],
+            ),
+            mock.patch("fishtest.views_run.get_nets", return_value=[]),
+        ):
+            with self.assertRaisesRegex(ValueError, "Number of games must be >= 1000"):
+                validate_form(request)
+
+    def test_validate_form_numgames_path_rejects_non_thousand_step_games(self):
+        post_data = _valid_post_data()
+        post_data["num-games"] = "1500"
+        request = _RequestStub(post_data=post_data)
+
+        with (
+            mock.patch(
+                "fishtest.views_run.gh.normalize_repo", side_effect=lambda repo: repo
+            ),
+            mock.patch(
+                "fishtest.views_run.gh.parse_repo",
+                return_value=("official-stockfish", "Stockfish"),
+            ),
+            mock.patch("fishtest.views_run.gh.get_master_repo", return_value=BASE_REPO),
+            mock.patch(
+                "fishtest.views_run.get_sha",
+                side_effect=[(BASE_SHA, "base"), (NEW_SHA, "new")],
+            ),
+            mock.patch("fishtest.views_run.get_nets", return_value=[]),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "Number of games must be a multiple of 1000",
+            ):
+                validate_form(request)
+
+    def test_validate_form_spsa_path_rejects_one_game_with_correct_message(self):
+        post_data = _valid_post_data()
+        post_data["stop_rule"] = "spsa"
+        post_data["num-games"] = "1"
+        post_data["spsa_A"] = "0.1"
+        post_data["spsa_alpha"] = "0.602"
+        post_data["spsa_gamma"] = "0.101"
+        post_data["spsa_raw_params"] = "Tempo,1,0,2,0.5,0.1"
+        request = _RequestStub(post_data=post_data)
+
+        with (
+            mock.patch(
+                "fishtest.views_run.gh.normalize_repo", side_effect=lambda repo: repo
+            ),
+            mock.patch(
+                "fishtest.views_run.gh.parse_repo",
+                return_value=("official-stockfish", "Stockfish"),
+            ),
+            mock.patch("fishtest.views_run.gh.get_master_repo", return_value=BASE_REPO),
+            mock.patch(
+                "fishtest.views_run.get_sha",
+                side_effect=[(BASE_SHA, "base"), (NEW_SHA, "new")],
+            ),
+            mock.patch("fishtest.views_run.get_nets", return_value=[]),
+        ):
+            with self.assertRaisesRegex(ValueError, "Number of games must be >= 1000"):
+                validate_form(request)
 
     def test_validate_form_canonicalizes_tests_repo_and_updates_user(self):
         post_data = _valid_post_data()
@@ -249,6 +381,50 @@ class ValidateFormTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(ValueError, "Invalid arch filter"):
                 validate_form(request)
+
+
+class TemplateConstraintContractTests(unittest.TestCase):
+    def test_tests_run_template_uses_shared_create_num_games_constraints(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        template_source = (
+            repo_root / "fishtest" / "templates" / "tests_run.html.j2"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            'min="{{ create_num_games_constraints.min }}"',
+            template_source,
+        )
+        self.assertIn(
+            'step="{{ create_num_games_constraints.step }}"',
+            template_source,
+        )
+        self.assertIn(
+            "const numGamesMin = {{ create_num_games_constraints.min }};",
+            template_source,
+        )
+        self.assertIn(
+            "const numGamesStep = {{ create_num_games_constraints.step }};",
+            template_source,
+        )
+        self.assertNotIn(
+            'document.getElementById("num-games").value = 1000 * Math.round(s.num_games / 1000);',
+            template_source,
+        )
+
+    def test_tests_view_template_uses_shared_modify_num_games_constraints(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        template_source = (
+            repo_root / "fishtest" / "templates" / "tests_view.html.j2"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            'min="{{ modify_num_games_constraints.min }}"',
+            template_source,
+        )
+        self.assertIn(
+            'step="{{ modify_num_games_constraints.step }}"',
+            template_source,
+        )
 
 
 class RunPermissionTests(unittest.TestCase):


### PR DESCRIPTION
Add `server/fishtest/spsa_workflow.py` as the shared owner for the live classic SPSA lifecycle: form defaults, SPSA state construction, raw-parameter parsing, detail formatting, worker-step generation, theta updates, and detail-page chart payload shaping.

Replace the inline classic SPSA parsing and state-building code in `views_run.py`, stop mutating rerun `A` values in `views.py` just to feed the template, and route SPSA detail formatting through the shared helper instead of keeping local duplicate formatter code in the view layer.

Update `spsa_handler.py` to use the shared worker-step, theta-update, and clip helpers, and return a shaped SPSA chart payload with precomputed `plot_live` data instead of returning the raw SPSA dict. Keep legacy missing algorithm values backward-compatible as classic, but reject unknown algorithm names.

Add focused SPSA workflow tests for the shared parser, worker update rule, form values, and chart payload contract, update detail/run tests for the new `plot_live` payload and explicit classic history rows, and drop the previous implementation-coupled JavaScript source-grep assertions.